### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
-	"packages/ui-components": "5.21.4",
+	"packages/ui-components": "5.22.0",
 	"packages/ui-hooks": "4.1.3",
-	"packages/ui-system": "1.4.4",
+	"packages/ui-system": "1.4.5",
 	"packages/ui-private": "1.4.8",
 	"packages/ui-icons": "1.12.0",
 	"packages/ui-styles": "1.9.6",
-	"packages/ui-form": "1.3.10",
+	"packages/ui-form": "1.3.11",
 	"packages/ui-fingerprint": "1.0.1",
-	"packages/ui-button": "0.0.0"
+	"packages/ui-button": "1.0.0"
 }

--- a/packages/ui-button/CHANGELOG.md
+++ b/packages/ui-button/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-15)
+
+
+### Features
+
+* **Button:** extracting Button and peers as a standalone package ([#635](https://github.com/versini-org/ui-components/issues/635)) ([651f857](https://github.com/versini-org/ui-components/commit/651f85739ba644cfa6d208e9779c8ded178f157b))

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-button",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -45,5 +47,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.22.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.21.4...ui-components-v5.22.0) (2024-09-15)
+
+
+### Features
+
+* **Button:** extracting Button and peers as a standalone package ([#635](https://github.com/versini-org/ui-components/issues/635)) ([651f857](https://github.com/versini-org/ui-components/commit/651f85739ba644cfa6d208e9779c8ded178f157b))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-button bumped to 1.0.0
+
 ## [5.21.4](https://github.com/versini-org/ui-components/compare/ui-components-v5.21.3...ui-components-v5.21.4) (2024-09-09)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.21.4",
+	"version": "5.22.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -52,5 +54,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.10"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -958,5 +958,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.22.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 43267,
+      "fileSizeGzip": 7000,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 36220,
+      "fileSizeGzip": 10113,
+      "limit": "10 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202715,
+      "fileSizeGzip": 67212,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.3.11](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.10...ui-form-v1.3.11) (2024-09-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-components bumped to 5.22.0
+
 ## [1.3.10](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.9...ui-form-v1.3.10) (2024-09-09)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.3.10",
+	"version": "1.3.11",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -49,5 +51,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"clsx": "2.1.1"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -222,5 +222,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.3.11": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 17769,
+      "fileSizeGzip": 5316,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-system/CHANGELOG.md
+++ b/packages/ui-system/CHANGELOG.md
@@ -31,6 +31,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.4.5](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.4...ui-system-v1.4.5) (2024-09-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-components bumped to 5.22.0
+
 ## [1.4.4](https://github.com/aversini/ui-components/compare/ui-system-v1.4.3...ui-system-v1.4.4) (2024-08-25)
 
 

--- a/packages/ui-system/package.json
+++ b/packages/ui-system/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-system",
-	"version": "1.4.4",
+	"version": "1.4.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -50,5 +52,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.10"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-system/stats/stats.json
+++ b/packages/ui-system/stats/stats.json
@@ -238,5 +238,25 @@
       "limit": "46 KB",
       "passed": true
     }
+  },
+  "1.4.5": {
+    "../bundlesize/dist/system/assets/style.css": {
+      "fileSize": 51950,
+      "fileSizeGzip": 7861,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/index.js": {
+      "fileSize": 5602,
+      "fileSizeGzip": 1979,
+      "limit": "3 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "46 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-button: 1.0.0</summary>

## 1.0.0 (2024-09-15)


### Features

* **Button:** extracting Button and peers as a standalone package ([#635](https://github.com/versini-org/ui-components/issues/635)) ([651f857](https://github.com/versini-org/ui-components/commit/651f85739ba644cfa6d208e9779c8ded178f157b))
</details>

<details><summary>ui-components: 5.22.0</summary>

## [5.22.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.21.4...ui-components-v5.22.0) (2024-09-15)


### Features

* **Button:** extracting Button and peers as a standalone package ([#635](https://github.com/versini-org/ui-components/issues/635)) ([651f857](https://github.com/versini-org/ui-components/commit/651f85739ba644cfa6d208e9779c8ded178f157b))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-button bumped to 1.0.0
</details>

<details><summary>ui-form: 1.3.11</summary>

## [1.3.11](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.10...ui-form-v1.3.11) (2024-09-15)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-components bumped to 5.22.0
</details>

<details><summary>ui-system: 1.4.5</summary>

## [1.4.5](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.4...ui-system-v1.4.5) (2024-09-15)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-components bumped to 5.22.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).