### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
-	"packages/ui-components": "5.22.0",
+	"packages/ui-components": "5.22.1",
 	"packages/ui-hooks": "4.1.3",
-	"packages/ui-system": "1.4.5",
-	"packages/ui-private": "1.4.8",
-	"packages/ui-icons": "1.12.0",
-	"packages/ui-styles": "1.9.6",
-	"packages/ui-form": "1.3.11",
+	"packages/ui-system": "1.4.6",
+	"packages/ui-private": "1.4.9",
+	"packages/ui-icons": "1.12.1",
+	"packages/ui-styles": "1.9.7",
+	"packages/ui-form": "1.3.12",
 	"packages/ui-fingerprint": "1.0.1",
-	"packages/ui-button": "1.0.0"
+	"packages/ui-button": "1.0.1"
 }

--- a/packages/ui-button/CHANGELOG.md
+++ b/packages/ui-button/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.1](https://github.com/versini-org/ui-components/compare/ui-button-v1.0.0...ui-button-v1.0.1) (2024-09-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-private bumped to 1.4.9
+  * devDependencies
+    * @versini/ui-icons bumped to 1.12.1
+    * @versini/ui-styles bumped to 1.9.7
+
 ## 1.0.0 (2024-09-15)
 
 

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-button",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.22.1](https://github.com/versini-org/ui-components/compare/ui-components-v5.22.0...ui-components-v5.22.1) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-button bumped to 1.0.1
+    * @versini/ui-icons bumped to 1.12.1
+    * @versini/ui-private bumped to 1.4.9
+  * devDependencies
+    * @versini/ui-styles bumped to 1.9.7
+
 ## [5.22.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.21.4...ui-components-v5.22.0) (2024-09-15)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.22.0",
+	"version": "5.22.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -52,5 +54,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -978,5 +978,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.22.1": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 43267,
+      "fileSizeGzip": 7000,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 36220,
+      "fileSizeGzip": 10117,
+      "limit": "10 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,19 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.3.12](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.11...ui-form-v1.3.12) (2024-09-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-private bumped to 1.4.9
+  * devDependencies
+    * @versini/ui-components bumped to 5.22.1
+    * @versini/ui-icons bumped to 1.12.1
+    * @versini/ui-styles bumped to 1.9.7
+
 ## [1.3.11](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.10...ui-form-v1.3.11) (2024-09-15)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -236,5 +236,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.3.12": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 17769,
+      "fileSizeGzip": 5320,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-icons/CHANGELOG.md
+++ b/packages/ui-icons/CHANGELOG.md
@@ -35,6 +35,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.12.1](https://github.com/versini-org/ui-components/compare/ui-icons-v1.12.0...ui-icons-v1.12.1) (2024-09-15)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-private bumped to 1.4.9
+  * devDependencies
+    * @versini/ui-private bumped to 1.4.9
+
 ## [1.12.0](https://github.com/versini-org/ui-components/compare/ui-icons-v1.11.0...ui-icons-v1.12.0) (2024-08-31)
 
 

--- a/packages/ui-icons/package.json
+++ b/packages/ui-icons/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-icons",
-	"version": "1.12.0",
+	"version": "1.12.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:icons": "node lib/buildIcons.js",
@@ -42,5 +44,7 @@
 	"dependencies": {
 		"@versini/ui-private": "workspace:../ui-private"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-private/CHANGELOG.md
+++ b/packages/ui-private/CHANGELOG.md
@@ -33,6 +33,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.4.9](https://github.com/versini-org/ui-components/compare/ui-private-v1.4.8...ui-private-v1.4.9) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-styles bumped to 1.9.7
+
 ## [1.4.8](https://github.com/aversini/ui-components/compare/ui-private-v1.4.7...ui-private-v1.4.8) (2024-08-25)
 
 

--- a/packages/ui-private/package.json
+++ b/packages/ui-private/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-private",
-	"version": "1.4.8",
+	"version": "1.4.9",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -45,5 +47,7 @@
 		"@versini/ui-hooks": "workspace:../ui-hooks",
 		"clsx": "2.1.1"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-styles/CHANGELOG.md
+++ b/packages/ui-styles/CHANGELOG.md
@@ -38,6 +38,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.9.7](https://github.com/versini-org/ui-components/compare/ui-styles-v1.9.6...ui-styles-v1.9.7) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))
+
 ## [1.9.6](https://github.com/versini-org/ui-components/compare/ui-styles-v1.9.5...ui-styles-v1.9.6) (2024-09-05)
 
 

--- a/packages/ui-styles/package.json
+++ b/packages/ui-styles/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-styles",
-	"version": "1.9.6",
+	"version": "1.9.7",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",

--- a/packages/ui-system/CHANGELOG.md
+++ b/packages/ui-system/CHANGELOG.md
@@ -31,6 +31,23 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.4.6](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.5...ui-system-v1.4.6) (2024-09-15)
+
+
+### Bug Fixes
+
+* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-private bumped to 1.4.9
+  * devDependencies
+    * @versini/ui-components bumped to 5.22.1
+    * @versini/ui-styles bumped to 1.9.7
+
 ## [1.4.5](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.4...ui-system-v1.4.5) (2024-09-15)
 
 

--- a/packages/ui-system/package.json
+++ b/packages/ui-system/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-system",
-	"version": "1.4.5",
+	"version": "1.4.6",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -50,5 +52,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-system/stats/stats.json
+++ b/packages/ui-system/stats/stats.json
@@ -258,5 +258,25 @@
       "limit": "46 KB",
       "passed": true
     }
+  },
+  "1.4.6": {
+    "../bundlesize/dist/system/assets/style.css": {
+      "fileSize": 51950,
+      "fileSizeGzip": 7861,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/index.js": {
+      "fileSize": 5602,
+      "fileSizeGzip": 1979,
+      "limit": "3 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "46 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-button: 1.0.1</summary>

## [1.0.1](https://github.com/versini-org/ui-components/compare/ui-button-v1.0.0...ui-button-v1.0.1) (2024-09-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-private bumped to 1.4.9
  * devDependencies
    * @versini/ui-icons bumped to 1.12.1
    * @versini/ui-styles bumped to 1.9.7
</details>

<details><summary>ui-components: 5.22.1</summary>

## [5.22.1](https://github.com/versini-org/ui-components/compare/ui-components-v5.22.0...ui-components-v5.22.1) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-button bumped to 1.0.1
    * @versini/ui-icons bumped to 1.12.1
    * @versini/ui-private bumped to 1.4.9
  * devDependencies
    * @versini/ui-styles bumped to 1.9.7
</details>

<details><summary>ui-form: 1.3.12</summary>

## [1.3.12](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.11...ui-form-v1.3.12) (2024-09-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-private bumped to 1.4.9
  * devDependencies
    * @versini/ui-components bumped to 5.22.1
    * @versini/ui-icons bumped to 1.12.1
    * @versini/ui-styles bumped to 1.9.7
</details>

<details><summary>ui-icons: 1.12.1</summary>

## [1.12.1](https://github.com/versini-org/ui-components/compare/ui-icons-v1.12.0...ui-icons-v1.12.1) (2024-09-15)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-private bumped to 1.4.9
  * devDependencies
    * @versini/ui-private bumped to 1.4.9
</details>

<details><summary>ui-private: 1.4.9</summary>

## [1.4.9](https://github.com/versini-org/ui-components/compare/ui-private-v1.4.8...ui-private-v1.4.9) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-styles bumped to 1.9.7
</details>

<details><summary>ui-styles: 1.9.7</summary>

## [1.9.7](https://github.com/versini-org/ui-components/compare/ui-styles-v1.9.6...ui-styles-v1.9.7) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))
</details>

<details><summary>ui-system: 1.4.6</summary>

## [1.4.6](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.5...ui-system-v1.4.6) (2024-09-15)


### Bug Fixes

* bump dependencies to latest ([#637](https://github.com/versini-org/ui-components/issues/637)) ([428b40e](https://github.com/versini-org/ui-components/commit/428b40e3d7d872b786cb5216bbade31dcc1c7d2b))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-private bumped to 1.4.9
  * devDependencies
    * @versini/ui-components bumped to 5.22.1
    * @versini/ui-styles bumped to 1.9.7
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).