### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,11 @@
 {
-	"packages/ui-components": "5.22.2",
+	"packages/ui-components": "5.23.0",
 	"packages/ui-hooks": "4.1.3",
-	"packages/ui-system": "1.4.7",
+	"packages/ui-system": "1.4.8",
 	"packages/ui-private": "1.4.9",
 	"packages/ui-icons": "1.12.1",
 	"packages/ui-styles": "1.9.7",
-	"packages/ui-form": "1.3.13",
+	"packages/ui-form": "1.3.14",
 	"packages/ui-fingerprint": "1.0.1",
 	"packages/ui-button": "1.0.2",
 	"packages/ui-anchor": "1.0.1"

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.23.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.22.2...ui-components-v5.23.0) (2024-09-16)
+
+
+### Features
+
+* **Bubble:** extracting Bubble as a standalone package ([#646](https://github.com/versini-org/ui-components/issues/646)) ([7eb19b7](https://github.com/versini-org/ui-components/commit/7eb19b791ba2d13c72d2b19bb0a01626f0ee3b97))
+
 ## [5.22.2](https://github.com/versini-org/ui-components/compare/ui-components-v5.22.1...ui-components-v5.22.2) (2024-09-16)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.22.2",
+	"version": "5.23.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -54,5 +56,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1018,5 +1018,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.23.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 38400,
+      "fileSizeGzip": 6337,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 54891,
+      "fileSizeGzip": 10996,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.3.14](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.13...ui-form-v1.3.14) (2024-09-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-components bumped to 5.23.0
+
 ## [1.3.13](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.12...ui-form-v1.3.13) (2024-09-16)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -264,5 +264,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.3.14": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 17769,
+      "fileSizeGzip": 5317,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-system/CHANGELOG.md
+++ b/packages/ui-system/CHANGELOG.md
@@ -31,6 +31,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.4.8](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.7...ui-system-v1.4.8) (2024-09-16)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-components bumped to 5.23.0
+
 ## [1.4.7](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.6...ui-system-v1.4.7) (2024-09-16)
 
 

--- a/packages/ui-system/package.json
+++ b/packages/ui-system/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-system",
-	"version": "1.4.7",
+	"version": "1.4.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-system/stats/stats.json
+++ b/packages/ui-system/stats/stats.json
@@ -298,5 +298,25 @@
       "limit": "46 KB",
       "passed": true
     }
+  },
+  "1.4.8": {
+    "../bundlesize/dist/system/assets/style.css": {
+      "fileSize": 51950,
+      "fileSizeGzip": 7861,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/index.js": {
+      "fileSize": 5602,
+      "fileSizeGzip": 1980,
+      "limit": "3 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "46 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.23.0</summary>

## [5.23.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.22.2...ui-components-v5.23.0) (2024-09-16)


### Features

* **Bubble:** extracting Bubble as a standalone package ([#646](https://github.com/versini-org/ui-components/issues/646)) ([7eb19b7](https://github.com/versini-org/ui-components/commit/7eb19b791ba2d13c72d2b19bb0a01626f0ee3b97))
</details>

<details><summary>ui-form: 1.3.14</summary>

## [1.3.14](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.13...ui-form-v1.3.14) (2024-09-16)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-components bumped to 5.23.0
</details>

<details><summary>ui-system: 1.4.8</summary>

## [1.4.8](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.7...ui-system-v1.4.8) (2024-09-16)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-components bumped to 5.23.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).