### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,14 +1,14 @@
 {
-	"packages/ui-components": "5.24.0",
+	"packages/ui-components": "5.24.1",
 	"packages/ui-hooks": "4.1.3",
-	"packages/ui-system": "1.4.9",
+	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
 	"packages/ui-icons": "1.12.1",
 	"packages/ui-styles": "1.9.7",
-	"packages/ui-form": "1.3.15",
+	"packages/ui-form": "1.3.16",
 	"packages/ui-fingerprint": "1.0.1",
-	"packages/ui-button": "1.0.2",
-	"packages/ui-anchor": "1.0.1",
-	"packages/ui-bubble": "0.0.0",
-	"packages/ui-card": "0.0.0"
+	"packages/ui-button": "1.1.0",
+	"packages/ui-anchor": "1.1.0",
+	"packages/ui-bubble": "1.0.0",
+	"packages/ui-card": "1.0.0"
 }

--- a/packages/ui-anchor/CHANGELOG.md
+++ b/packages/ui-anchor/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [1.1.0](https://github.com/versini-org/ui-components/compare/ui-anchor-v1.0.1...ui-anchor-v1.1.0) (2024-09-17)
+
+
+### Features
+
+* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-button bumped to 1.1.0
+
 ## [1.0.1](https://github.com/versini-org/ui-components/compare/ui-anchor-v1.0.0...ui-anchor-v1.0.1) (2024-09-16)
 
 

--- a/packages/ui-anchor/package.json
+++ b/packages/ui-anchor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-anchor",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-bubble/CHANGELOG.md
+++ b/packages/ui-bubble/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Bubble:** extracting Bubble as a standalone package ([#646](https://github.com/versini-org/ui-components/issues/646)) ([7eb19b7](https://github.com/versini-org/ui-components/commit/7eb19b791ba2d13c72d2b19bb0a01626f0ee3b97))
+* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))
+
+
+### Bug Fixes
+
+* **Bubble:** invalid name for analytics ([#650](https://github.com/versini-org/ui-components/issues/650)) ([1575d09](https://github.com/versini-org/ui-components/commit/1575d09a40bd27964ec155caabe1b56d2c3ad2d4))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-button bumped to 1.1.0

--- a/packages/ui-bubble/package.json
+++ b/packages/ui-bubble/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-bubble",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -46,5 +48,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-button/CHANGELOG.md
+++ b/packages/ui-button/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0](https://github.com/versini-org/ui-components/compare/ui-button-v1.0.2...ui-button-v1.1.0) (2024-09-17)
+
+
+### Features
+
+* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))
+
 ## [1.0.2](https://github.com/versini-org/ui-components/compare/ui-button-v1.0.1...ui-button-v1.0.2) (2024-09-16)
 
 

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-button",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-card/CHANGELOG.md
+++ b/packages/ui-card/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Card:** extracting Card as a standalone package ([#648](https://github.com/versini-org/ui-components/issues/648)) ([1a08557](https://github.com/versini-org/ui-components/commit/1a0855708584f41c825efe170da4aa13ff163453))
+* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))

--- a/packages/ui-card/package.json
+++ b/packages/ui-card/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-card",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -46,5 +48,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.24.1](https://github.com/versini-org/ui-components/compare/ui-components-v5.24.0...ui-components-v5.24.1) (2024-09-17)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-anchor bumped to 1.1.0
+    * @versini/ui-button bumped to 1.1.0
+    * @versini/ui-bubble bumped to 1.0.0
+    * @versini/ui-card bumped to 1.0.0
+
 ## [5.24.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.23.0...ui-components-v5.24.0) (2024-09-16)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.24.0",
+	"version": "5.24.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1058,5 +1058,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.24.1": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 37613,
+      "fileSizeGzip": 6245,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 55447,
+      "fileSizeGzip": 11026,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.3.16](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.15...ui-form-v1.3.16) (2024-09-17)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-button bumped to 1.1.0
+
 ## [1.3.15](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.14...ui-form-v1.3.15) (2024-09-16)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.3.15",
+	"version": "1.3.16",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -49,5 +51,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"clsx": "2.1.1"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -292,5 +292,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.3.16": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 17769,
+      "fileSizeGzip": 5316,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-system/CHANGELOG.md
+++ b/packages/ui-system/CHANGELOG.md
@@ -31,6 +31,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.4.10](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.9...ui-system-v1.4.10) (2024-09-17)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * devDependencies
+    * @versini/ui-button bumped to 1.1.0
+
 ## [1.4.9](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.8...ui-system-v1.4.9) (2024-09-16)
 
 

--- a/packages/ui-system/package.json
+++ b/packages/ui-system/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-system",
-	"version": "1.4.9",
+	"version": "1.4.10",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -50,5 +52,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-system/stats/stats.json
+++ b/packages/ui-system/stats/stats.json
@@ -338,5 +338,25 @@
       "limit": "46 KB",
       "passed": true
     }
+  },
+  "1.4.10": {
+    "../bundlesize/dist/system/assets/style.css": {
+      "fileSize": 12627,
+      "fileSizeGzip": 2638,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/index.js": {
+      "fileSize": 5604,
+      "fileSizeGzip": 1980,
+      "limit": "3 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/system/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "46 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-anchor: 1.1.0</summary>

## [1.1.0](https://github.com/versini-org/ui-components/compare/ui-anchor-v1.0.1...ui-anchor-v1.1.0) (2024-09-17)


### Features

* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-button bumped to 1.1.0
</details>

<details><summary>ui-bubble: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Bubble:** extracting Bubble as a standalone package ([#646](https://github.com/versini-org/ui-components/issues/646)) ([7eb19b7](https://github.com/versini-org/ui-components/commit/7eb19b791ba2d13c72d2b19bb0a01626f0ee3b97))
* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))


### Bug Fixes

* **Bubble:** invalid name for analytics ([#650](https://github.com/versini-org/ui-components/issues/650)) ([1575d09](https://github.com/versini-org/ui-components/commit/1575d09a40bd27964ec155caabe1b56d2c3ad2d4))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-button bumped to 1.1.0
</details>

<details><summary>ui-button: 1.1.0</summary>

## [1.1.0](https://github.com/versini-org/ui-components/compare/ui-button-v1.0.2...ui-button-v1.1.0) (2024-09-17)


### Features

* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))
</details>

<details><summary>ui-card: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Card:** extracting Card as a standalone package ([#648](https://github.com/versini-org/ui-components/issues/648)) ([1a08557](https://github.com/versini-org/ui-components/commit/1a0855708584f41c825efe170da4aa13ff163453))
* simplification of the global name for individual components ([#652](https://github.com/versini-org/ui-components/issues/652)) ([91c6c85](https://github.com/versini-org/ui-components/commit/91c6c857e38f8368c509a04e63912a35e75c2053))
</details>

<details><summary>ui-components: 5.24.1</summary>

## [5.24.1](https://github.com/versini-org/ui-components/compare/ui-components-v5.24.0...ui-components-v5.24.1) (2024-09-17)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-anchor bumped to 1.1.0
    * @versini/ui-button bumped to 1.1.0
    * @versini/ui-bubble bumped to 1.0.0
    * @versini/ui-card bumped to 1.0.0
</details>

<details><summary>ui-form: 1.3.16</summary>

## [1.3.16](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.15...ui-form-v1.3.16) (2024-09-17)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-button bumped to 1.1.0
</details>

<details><summary>ui-system: 1.4.10</summary>

## [1.4.10](https://github.com/versini-org/ui-components/compare/ui-system-v1.4.9...ui-system-v1.4.10) (2024-09-17)


### Dependencies

* The following workspace dependencies were updated
  * devDependencies
    * @versini/ui-button bumped to 1.1.0
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).