### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.24.1",
+	"packages/ui-components": "5.25.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -11,5 +11,5 @@
 	"packages/ui-anchor": "1.1.0",
 	"packages/ui-bubble": "1.0.0",
 	"packages/ui-card": "1.0.0",
-	"packages/ui-footer": "0.0.0"
+	"packages/ui-footer": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.25.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.24.1...ui-components-v5.25.0) (2024-09-17)
+
+
+### Features
+
+* **Footer:** extracting Footer as a standalone package ([#655](https://github.com/versini-org/ui-components/issues/655)) ([8808a2a](https://github.com/versini-org/ui-components/commit/8808a2a3f0490894a072f8fe1f3e4bd8bf94ed6f))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-footer bumped to 1.0.0
+
 ## [5.24.1](https://github.com/versini-org/ui-components/compare/ui-components-v5.24.0...ui-components-v5.24.1) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.24.1",
+	"version": "5.25.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -56,5 +58,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1078,5 +1078,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.25.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 37318,
+      "fileSizeGzip": 6204,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 56015,
+      "fileSizeGzip": 11099,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-footer/CHANGELOG.md
+++ b/packages/ui-footer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Footer:** extracting Footer as a standalone package ([#655](https://github.com/versini-org/ui-components/issues/655)) ([8808a2a](https://github.com/versini-org/ui-components/commit/8808a2a3f0490894a072f8fe1f3e4bd8bf94ed6f))

--- a/packages/ui-footer/package.json
+++ b/packages/ui-footer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-footer",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -43,5 +45,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.25.0</summary>

## [5.25.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.24.1...ui-components-v5.25.0) (2024-09-17)


### Features

* **Footer:** extracting Footer as a standalone package ([#655](https://github.com/versini-org/ui-components/issues/655)) ([8808a2a](https://github.com/versini-org/ui-components/commit/8808a2a3f0490894a072f8fe1f3e4bd8bf94ed6f))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-footer bumped to 1.0.0
</details>

<details><summary>ui-footer: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Footer:** extracting Footer as a standalone package ([#655](https://github.com/versini-org/ui-components/issues/655)) ([8808a2a](https://github.com/versini-org/ui-components/commit/8808a2a3f0490894a072f8fe1f3e4bd8bf94ed6f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).