### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.25.0",
+	"packages/ui-components": "5.26.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -12,5 +12,5 @@
 	"packages/ui-bubble": "1.0.0",
 	"packages/ui-card": "1.0.0",
 	"packages/ui-footer": "1.0.0",
-	"packages/ui-header": "0.0.0"
+	"packages/ui-header": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.26.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.25.0...ui-components-v5.26.0) (2024-09-17)
+
+
+### Features
+
+* **Header:** extracting Header as a standalone package ([#657](https://github.com/versini-org/ui-components/issues/657)) ([df9d2d9](https://github.com/versini-org/ui-components/commit/df9d2d9b52123e80929f46952078cf45ca52073f))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-header bumped to 1.0.0
+
 ## [5.25.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.24.1...ui-components-v5.25.0) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.25.0",
+	"version": "5.26.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -57,5 +59,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1098,5 +1098,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.26.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 36782,
+      "fileSizeGzip": 6173,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 56583,
+      "fileSizeGzip": 11145,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-header/CHANGELOG.md
+++ b/packages/ui-header/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Header:** extracting Header as a standalone package ([#657](https://github.com/versini-org/ui-components/issues/657)) ([df9d2d9](https://github.com/versini-org/ui-components/commit/df9d2d9b52123e80929f46952078cf45ca52073f))

--- a/packages/ui-header/package.json
+++ b/packages/ui-header/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-header",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -44,5 +46,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.26.0</summary>

## [5.26.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.25.0...ui-components-v5.26.0) (2024-09-17)


### Features

* **Header:** extracting Header as a standalone package ([#657](https://github.com/versini-org/ui-components/issues/657)) ([df9d2d9](https://github.com/versini-org/ui-components/commit/df9d2d9b52123e80929f46952078cf45ca52073f))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-header bumped to 1.0.0
</details>

<details><summary>ui-header: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Header:** extracting Header as a standalone package ([#657](https://github.com/versini-org/ui-components/issues/657)) ([df9d2d9](https://github.com/versini-org/ui-components/commit/df9d2d9b52123e80929f46952078cf45ca52073f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).