### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.26.0",
+	"packages/ui-components": "5.27.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -13,5 +13,5 @@
 	"packages/ui-card": "1.0.0",
 	"packages/ui-footer": "1.0.0",
 	"packages/ui-header": "1.0.0",
-	"packages/ui-main": "0.0.0"
+	"packages/ui-main": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.27.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.26.0...ui-components-v5.27.0) (2024-09-17)
+
+
+### Features
+
+* **Main:** extracting Main as a standalone package ([#659](https://github.com/versini-org/ui-components/issues/659)) ([5e9330b](https://github.com/versini-org/ui-components/commit/5e9330b3f2250b3d1d34fc56b2f6c975532c38d2))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-main bumped to 1.0.0
+
 ## [5.26.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.25.0...ui-components-v5.26.0) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.26.0",
+	"version": "5.27.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -58,5 +60,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1118,5 +1118,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.27.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 36648,
+      "fileSizeGzip": 6142,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 57145,
+      "fileSizeGzip": 11138,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-main/CHANGELOG.md
+++ b/packages/ui-main/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Main:** extracting Main as a standalone package ([#659](https://github.com/versini-org/ui-components/issues/659)) ([5e9330b](https://github.com/versini-org/ui-components/commit/5e9330b3f2250b3d1d34fc56b2f6c975532c38d2))

--- a/packages/ui-main/package.json
+++ b/packages/ui-main/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-main",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -44,5 +46,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.27.0</summary>

## [5.27.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.26.0...ui-components-v5.27.0) (2024-09-17)


### Features

* **Main:** extracting Main as a standalone package ([#659](https://github.com/versini-org/ui-components/issues/659)) ([5e9330b](https://github.com/versini-org/ui-components/commit/5e9330b3f2250b3d1d34fc56b2f6c975532c38d2))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-main bumped to 1.0.0
</details>

<details><summary>ui-main: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Main:** extracting Main as a standalone package ([#659](https://github.com/versini-org/ui-components/issues/659)) ([5e9330b](https://github.com/versini-org/ui-components/commit/5e9330b3f2250b3d1d34fc56b2f6c975532c38d2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).