### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.27.0",
+	"packages/ui-components": "5.28.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -14,5 +14,5 @@
 	"packages/ui-footer": "1.0.0",
 	"packages/ui-header": "1.0.0",
 	"packages/ui-main": "1.0.0",
-	"packages/ui-menu": "0.0.0"
+	"packages/ui-menu": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.28.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.27.0...ui-components-v5.28.0) (2024-09-17)
+
+
+### Features
+
+* **Menu:** extracting Menu as a standalone package ([#661](https://github.com/versini-org/ui-components/issues/661)) ([c1065c3](https://github.com/versini-org/ui-components/commit/c1065c3da576d28ccc484234bb03d0ad24c4d51a))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-menu bumped to 1.0.0
+
 ## [5.27.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.26.0...ui-components-v5.27.0) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.27.0",
+	"version": "5.28.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -59,5 +61,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1138,5 +1138,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.28.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 35112,
+      "fileSizeGzip": 5885,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 57395,
+      "fileSizeGzip": 11178,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 202712,
+      "fileSizeGzip": 67201,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-menu/CHANGELOG.md
+++ b/packages/ui-menu/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Menu:** extracting Menu as a standalone package ([#661](https://github.com/versini-org/ui-components/issues/661)) ([c1065c3](https://github.com/versini-org/ui-components/commit/c1065c3da576d28ccc484234bb03d0ad24c4d51a))

--- a/packages/ui-menu/package.json
+++ b/packages/ui-menu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-menu",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -46,5 +48,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.28.0</summary>

## [5.28.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.27.0...ui-components-v5.28.0) (2024-09-17)


### Features

* **Menu:** extracting Menu as a standalone package ([#661](https://github.com/versini-org/ui-components/issues/661)) ([c1065c3](https://github.com/versini-org/ui-components/commit/c1065c3da576d28ccc484234bb03d0ad24c4d51a))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-menu bumped to 1.0.0
</details>

<details><summary>ui-menu: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Menu:** extracting Menu as a standalone package ([#661](https://github.com/versini-org/ui-components/issues/661)) ([c1065c3](https://github.com/versini-org/ui-components/commit/c1065c3da576d28ccc484234bb03d0ad24c4d51a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).