### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.28.0",
+	"packages/ui-components": "5.29.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -15,5 +15,5 @@
 	"packages/ui-header": "1.0.0",
 	"packages/ui-main": "1.0.0",
 	"packages/ui-menu": "1.0.0",
-	"packages/ui-panel": "0.0.0"
+	"packages/ui-panel": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.29.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.28.0...ui-components-v5.29.0) (2024-09-17)
+
+
+### Features
+
+* **Panel:** extracting Panel as a standalone package ([#663](https://github.com/versini-org/ui-components/issues/663)) ([3450a8f](https://github.com/versini-org/ui-components/commit/3450a8fd5e72d5a5cb6cccf0dc0836d810850cf2))
+* **Pill:** extracting Pill as a standalone package ([#665](https://github.com/versini-org/ui-components/issues/665)) ([0f13fae](https://github.com/versini-org/ui-components/commit/0f13faea848ff6dd561837ccc439cd0bde69c67d))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-panel bumped to 1.0.0
+
 ## [5.28.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.27.0...ui-components-v5.28.0) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.28.0",
+	"version": "5.29.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -61,5 +63,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1158,5 +1158,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.29.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 18364,
+      "fileSizeGzip": 3655,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 67287,
+      "fileSizeGzip": 10926,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 203647,
+      "fileSizeGzip": 67641,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-panel/CHANGELOG.md
+++ b/packages/ui-panel/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Panel:** extracting Panel as a standalone package ([#663](https://github.com/versini-org/ui-components/issues/663)) ([3450a8f](https://github.com/versini-org/ui-components/commit/3450a8fd5e72d5a5cb6cccf0dc0836d810850cf2))

--- a/packages/ui-panel/package.json
+++ b/packages/ui-panel/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-panel",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -46,5 +48,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.29.0</summary>

## [5.29.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.28.0...ui-components-v5.29.0) (2024-09-17)


### Features

* **Panel:** extracting Panel as a standalone package ([#663](https://github.com/versini-org/ui-components/issues/663)) ([3450a8f](https://github.com/versini-org/ui-components/commit/3450a8fd5e72d5a5cb6cccf0dc0836d810850cf2))
* **Pill:** extracting Pill as a standalone package ([#665](https://github.com/versini-org/ui-components/issues/665)) ([0f13fae](https://github.com/versini-org/ui-components/commit/0f13faea848ff6dd561837ccc439cd0bde69c67d))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-panel bumped to 1.0.0
</details>

<details><summary>ui-panel: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Panel:** extracting Panel as a standalone package ([#663](https://github.com/versini-org/ui-components/issues/663)) ([3450a8f](https://github.com/versini-org/ui-components/commit/3450a8fd5e72d5a5cb6cccf0dc0836d810850cf2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).