### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.29.0",
+	"packages/ui-components": "5.30.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -16,6 +16,6 @@
 	"packages/ui-main": "1.0.0",
 	"packages/ui-menu": "1.0.0",
 	"packages/ui-panel": "1.0.0",
-	"packages/ui-pill": "0.0.0",
-	"packages/ui-spinner": "0.0.0"
+	"packages/ui-pill": "1.0.0",
+	"packages/ui-spinner": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,21 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.30.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.29.0...ui-components-v5.30.0) (2024-09-17)
+
+
+### Features
+
+* **Spinner:** extracting Spinner as a standalone package ([#666](https://github.com/versini-org/ui-components/issues/666)) ([d607d22](https://github.com/versini-org/ui-components/commit/d607d224c302c544a873515a31e5a2c8a285ca03))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-pill bumped to 1.0.0
+    * @versini/ui-spinner bumped to 1.0.0
+
 ## [5.29.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.28.0...ui-components-v5.29.0) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.29.0",
+	"version": "5.30.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -62,5 +64,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1178,5 +1178,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.30.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 16903,
+      "fileSizeGzip": 3280,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 67858,
+      "fileSizeGzip": 10943,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 203647,
+      "fileSizeGzip": 67641,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-pill/CHANGELOG.md
+++ b/packages/ui-pill/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Pill:** extracting Pill as a standalone package ([#665](https://github.com/versini-org/ui-components/issues/665)) ([0f13fae](https://github.com/versini-org/ui-components/commit/0f13faea848ff6dd561837ccc439cd0bde69c67d))

--- a/packages/ui-pill/package.json
+++ b/packages/ui-pill/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-pill",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -44,5 +46,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-spinner/CHANGELOG.md
+++ b/packages/ui-spinner/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Spinner:** extracting Spinner as a standalone package ([#666](https://github.com/versini-org/ui-components/issues/666)) ([d607d22](https://github.com/versini-org/ui-components/commit/d607d224c302c544a873515a31e5a2c8a285ca03))

--- a/packages/ui-spinner/package.json
+++ b/packages/ui-spinner/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-spinner",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -43,5 +45,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.30.0</summary>

## [5.30.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.29.0...ui-components-v5.30.0) (2024-09-17)


### Features

* **Spinner:** extracting Spinner as a standalone package ([#666](https://github.com/versini-org/ui-components/issues/666)) ([d607d22](https://github.com/versini-org/ui-components/commit/d607d224c302c544a873515a31e5a2c8a285ca03))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-pill bumped to 1.0.0
    * @versini/ui-spinner bumped to 1.0.0
</details>

<details><summary>ui-pill: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Pill:** extracting Pill as a standalone package ([#665](https://github.com/versini-org/ui-components/issues/665)) ([0f13fae](https://github.com/versini-org/ui-components/commit/0f13faea848ff6dd561837ccc439cd0bde69c67d))
</details>

<details><summary>ui-spinner: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Spinner:** extracting Spinner as a standalone package ([#666](https://github.com/versini-org/ui-components/issues/666)) ([d607d22](https://github.com/versini-org/ui-components/commit/d607d224c302c544a873515a31e5a2c8a285ca03))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).