### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-	"packages/ui-components": "5.30.0",
+	"packages/ui-components": "5.31.0",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-system": "1.4.10",
 	"packages/ui-private": "1.4.9",
@@ -18,5 +18,5 @@
 	"packages/ui-panel": "1.0.0",
 	"packages/ui-pill": "1.0.0",
 	"packages/ui-spinner": "1.0.0",
-	"packages/ui-table": "0.0.0"
+	"packages/ui-table": "1.0.0"
 }

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.31.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.30.0...ui-components-v5.31.0) (2024-09-17)
+
+
+### Features
+
+* **Table:** extracting Table as a standalone package ([#668](https://github.com/versini-org/ui-components/issues/668)) ([d2ad0f5](https://github.com/versini-org/ui-components/commit/d2ad0f568557c3fb409caa048c1f7a9a105763b9))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-table bumped to 1.0.0
+
 ## [5.30.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.29.0...ui-components-v5.30.0) (2024-09-17)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.30.0",
+	"version": "5.31.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -61,5 +63,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1198,5 +1198,25 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "5.31.0": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 9754,
+      "fileSizeGzip": 2294,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 75981,
+      "fileSizeGzip": 11152,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 203647,
+      "fileSizeGzip": 67641,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-table/CHANGELOG.md
+++ b/packages/ui-table/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-17)
+
+
+### Features
+
+* **Table:** extracting Table as a standalone package ([#668](https://github.com/versini-org/ui-components/issues/668)) ([d2ad0f5](https://github.com/versini-org/ui-components/commit/d2ad0f568557c3fb409caa048c1f7a9a105763b9))

--- a/packages/ui-table/package.json
+++ b/packages/ui-table/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-table",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -47,5 +49,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.11"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-components: 5.31.0</summary>

## [5.31.0](https://github.com/versini-org/ui-components/compare/ui-components-v5.30.0...ui-components-v5.31.0) (2024-09-17)


### Features

* **Table:** extracting Table as a standalone package ([#668](https://github.com/versini-org/ui-components/issues/668)) ([d2ad0f5](https://github.com/versini-org/ui-components/commit/d2ad0f568557c3fb409caa048c1f7a9a105763b9))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-table bumped to 1.0.0
</details>

<details><summary>ui-table: 1.0.0</summary>

## 1.0.0 (2024-09-17)


### Features

* **Table:** extracting Table as a standalone package ([#668](https://github.com/versini-org/ui-components/issues/668)) ([d2ad0f5](https://github.com/versini-org/ui-components/commit/d2ad0f568557c3fb409caa048c1f7a9a105763b9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).