### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,7 @@
 	"packages/ui-components": "5.31.1",
 	"packages/ui-fingerprint": "1.0.1",
 	"packages/ui-footer": "1.0.1",
-	"packages/ui-form": "1.3.17",
+	"packages/ui-form": "1.4.0",
 	"packages/ui-header": "1.0.1",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-icons": "1.12.2",
@@ -19,5 +19,5 @@
 	"packages/ui-styles": "1.9.8",
 	"packages/ui-system": "1.4.11",
 	"packages/ui-table": "1.0.1",
-	"packages/ui-toggle": "0.0.0"
+	"packages/ui-toggle": "1.0.0"
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.4.0](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.17...ui-form-v1.4.0) (2024-09-18)
+
+
+### Features
+
+* **Toggle:** extracting Toggle as a standalone package ([#672](https://github.com/versini-org/ui-components/issues/672)) ([1a215b5](https://github.com/versini-org/ui-components/commit/1a215b52aa70c6662bf5b12eddeb0d8adfd411fd))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-toggle bumped to 1.0.0
+
 ## [1.3.17](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.16...ui-form-v1.3.17) (2024-09-17)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.3.17",
+	"version": "1.4.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -50,5 +52,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"clsx": "2.1.1"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -320,5 +320,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.4.0": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 18331,
+      "fileSizeGzip": 5354,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-toggle/CHANGELOG.md
+++ b/packages/ui-toggle/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-18)
+
+
+### Features
+
+* **Toggle:** extracting Toggle as a standalone package ([#672](https://github.com/versini-org/ui-components/issues/672)) ([1a215b5](https://github.com/versini-org/ui-components/commit/1a215b52aa70c6662bf5b12eddeb0d8adfd411fd))

--- a/packages/ui-toggle/package.json
+++ b/packages/ui-toggle/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-toggle",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -44,5 +46,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.12"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-form: 1.4.0</summary>

## [1.4.0](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.17...ui-form-v1.4.0) (2024-09-18)


### Features

* **Toggle:** extracting Toggle as a standalone package ([#672](https://github.com/versini-org/ui-components/issues/672)) ([1a215b5](https://github.com/versini-org/ui-components/commit/1a215b52aa70c6662bf5b12eddeb0d8adfd411fd))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-toggle bumped to 1.0.0
</details>

<details><summary>ui-toggle: 1.0.0</summary>

## 1.0.0 (2024-09-18)


### Features

* **Toggle:** extracting Toggle as a standalone package ([#672](https://github.com/versini-org/ui-components/issues/672)) ([1a215b5](https://github.com/versini-org/ui-components/commit/1a215b52aa70c6662bf5b12eddeb0d8adfd411fd))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).