### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,7 @@
 	"packages/ui-components": "5.31.1",
 	"packages/ui-fingerprint": "1.0.1",
 	"packages/ui-footer": "1.0.1",
-	"packages/ui-form": "1.4.0",
+	"packages/ui-form": "1.5.0",
 	"packages/ui-header": "1.0.1",
 	"packages/ui-hooks": "4.1.3",
 	"packages/ui-icons": "1.12.2",
@@ -19,6 +19,6 @@
 	"packages/ui-styles": "1.9.8",
 	"packages/ui-system": "1.4.11",
 	"packages/ui-table": "1.0.1",
-	"packages/ui-textinput": "0.0.0",
+	"packages/ui-textinput": "1.0.0",
 	"packages/ui-toggle": "1.0.0"
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.5.0](https://github.com/versini-org/ui-components/compare/ui-form-v1.4.0...ui-form-v1.5.0) (2024-09-18)
+
+
+### Features
+
+* **TextInput:** extracting TextInput as a standalone package ([#674](https://github.com/versini-org/ui-components/issues/674)) ([34c0cf3](https://github.com/versini-org/ui-components/commit/34c0cf3254dc18a88bcab992a066c53e59f80e3f))
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-textinput bumped to 1.0.0
+
 ## [1.4.0](https://github.com/versini-org/ui-components/compare/ui-form-v1.3.17...ui-form-v1.4.0) (2024-09-18)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -51,5 +53,7 @@
 		"@versini/ui-private": "workspace:../ui-private",
 		"clsx": "2.1.1"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -334,5 +334,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.5.0": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 21791,
+      "fileSizeGzip": 5543,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-textinput/CHANGELOG.md
+++ b/packages/ui-textinput/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.0.0 (2024-09-18)
+
+
+### Features
+
+* **TextInput:** extracting TextInput as a standalone package ([#674](https://github.com/versini-org/ui-components/issues/674)) ([34c0cf3](https://github.com/versini-org/ui-components/commit/34c0cf3254dc18a88bcab992a066c53e59f80e3f))

--- a/packages/ui-textinput/package.json
+++ b/packages/ui-textinput/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-textinput",
-	"version": "0.0.0",
+	"version": "1.0.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {
@@ -14,7 +14,9 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -47,5 +49,7 @@
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.12"
 	},
-	"sideEffects": ["**/*.css"]
+	"sideEffects": [
+		"**/*.css"
+	]
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-form: 1.5.0</summary>

## [1.5.0](https://github.com/versini-org/ui-components/compare/ui-form-v1.4.0...ui-form-v1.5.0) (2024-09-18)


### Features

* **TextInput:** extracting TextInput as a standalone package ([#674](https://github.com/versini-org/ui-components/issues/674)) ([34c0cf3](https://github.com/versini-org/ui-components/commit/34c0cf3254dc18a88bcab992a066c53e59f80e3f))


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-textinput bumped to 1.0.0
</details>

<details><summary>ui-textinput: 1.0.0</summary>

## 1.0.0 (2024-09-18)


### Features

* **TextInput:** extracting TextInput as a standalone package ([#674](https://github.com/versini-org/ui-components/issues/674)) ([34c0cf3](https://github.com/versini-org/ui-components/commit/34c0cf3254dc18a88bcab992a066c53e59f80e3f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).