### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,7 @@
 	"packages/ui-components": "5.31.12",
 	"packages/ui-fingerprint": "1.0.1",
 	"packages/ui-footer": "1.0.8",
-	"packages/ui-form": "1.6.11",
+	"packages/ui-form": "1.6.12",
 	"packages/ui-header": "1.0.8",
 	"packages/ui-hooks": "4.2.1",
 	"packages/ui-icons": "1.13.1",
@@ -20,7 +20,7 @@
 	"packages/ui-system": "1.4.19",
 	"packages/ui-table": "1.0.10",
 	"packages/ui-textarea": "1.0.7",
-	"packages/ui-textinput": "1.1.6",
+	"packages/ui-textinput": "1.2.0",
 	"packages/ui-toggle": "1.0.7",
 	"packages/ui-truncate": "1.0.7"
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.6.12](https://github.com/versini-org/ui-components/compare/ui-form-v1.6.11...ui-form-v1.6.12) (2024-09-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-textinput bumped to 1.2.0
+
 ## [1.6.11](https://github.com/versini-org/ui-components/compare/ui-form-v1.6.10...ui-form-v1.6.11) (2024-09-28)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.6.11",
+	"version": "1.6.12",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -516,5 +516,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.6.12": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 22781,
+      "fileSizeGzip": 5813,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-textinput/CHANGELOG.md
+++ b/packages/ui-textinput/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.2.0](https://github.com/versini-org/ui-components/compare/ui-textinput-v1.1.6...ui-textinput-v1.2.0) (2024-09-30)
+
+
+### Features
+
+* **TextInput:** adding new prop: rightElementClassName ([#710](https://github.com/versini-org/ui-components/issues/710)) ([0374ebe](https://github.com/versini-org/ui-components/commit/0374ebe7bc477f949f3d652a78ee27a30299453f))
+
 ## [1.1.6](https://github.com/versini-org/ui-components/compare/ui-textinput-v1.1.5...ui-textinput-v1.1.6) (2024-09-28)
 
 

--- a/packages/ui-textinput/package.json
+++ b/packages/ui-textinput/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-textinput",
-	"version": "1.1.6",
+	"version": "1.2.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-form: 1.6.12</summary>

## [1.6.12](https://github.com/versini-org/ui-components/compare/ui-form-v1.6.11...ui-form-v1.6.12) (2024-09-30)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-textinput bumped to 1.2.0
</details>

<details><summary>ui-textinput: 1.2.0</summary>

## [1.2.0](https://github.com/versini-org/ui-components/compare/ui-textinput-v1.1.6...ui-textinput-v1.2.0) (2024-09-30)


### Features

* **TextInput:** adding new prop: rightElementClassName ([#710](https://github.com/versini-org/ui-components/issues/710)) ([0374ebe](https://github.com/versini-org/ui-components/commit/0374ebe7bc477f949f3d652a78ee27a30299453f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).