### PR TITLE
fix(ui-togglegroup): adding missing spacing implementation

### DIFF
--- a/packages/ui-togglegroup/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/ui-togglegroup/src/components/ToggleGroup/ToggleGroup.tsx
@@ -17,10 +17,11 @@ export const ToggleGroup = ({
 	focusMode = "system",
 	size = "medium",
 	defaultValue,
+	spacing,
 
 	...otherProps
 }: ToggleGroupProps) => {
-	const toggleGroupClasses = getToggleGroupClasses({ mode });
+	const toggleGroupClasses = getToggleGroupClasses({ mode, spacing });
 	const contextValue = { size, focusMode, mode };
 	return (
 		<ToggleGroupContext.Provider value={contextValue}>

--- a/packages/ui-togglegroup/src/components/ToggleGroup/utilities.ts
+++ b/packages/ui-togglegroup/src/components/ToggleGroup/utilities.ts
@@ -1,4 +1,7 @@
+import type { SpacingProps } from "@versini/ui-private/dist/utilities";
+import { getSpacing } from "@versini/ui-private/dist/utilities";
 import clsx from "clsx";
+
 import { TOGGLEGROUP_CLASSNAME } from "../../common/constants";
 import type { Mode, Size } from "./ToggleGroupTypes";
 
@@ -53,13 +56,22 @@ export const getToggleGroupItemClasses = ({
 	);
 };
 
-export const getToggleGroupClasses = ({ mode }: { mode: Mode }) => {
-	return clsx(TOGGLEGROUP_CLASSNAME, "inline-flex p-1", "rounded-sm", {
-		"bg-surface-light text-copy-dark": mode === "light",
-		"bg-surface-darker text-copy-lighter": mode === "dark",
-		"bg-surface-light text-copy-dark dark:bg-surface-darker dark:text-copy-lighter":
-			mode === "system",
-		"bg-surface-darker text-copy-lighter dark:bg-surface-light dark:text-copy-dark":
-			mode === "alt-system",
-	});
+export const getToggleGroupClasses = ({
+	mode,
+	spacing,
+}: { mode: Mode } & SpacingProps) => {
+	return clsx(
+		TOGGLEGROUP_CLASSNAME,
+		getSpacing(spacing),
+		"inline-flex p-1",
+		"rounded-sm",
+		{
+			"bg-surface-light text-copy-dark": mode === "light",
+			"bg-surface-darker text-copy-lighter": mode === "dark",
+			"bg-surface-light text-copy-dark dark:bg-surface-darker dark:text-copy-lighter":
+				mode === "system",
+			"bg-surface-darker text-copy-lighter dark:bg-surface-light dark:text-copy-dark":
+				mode === "alt-system",
+		},
+	);
 };


### PR DESCRIPTION
This pull request introduces a new `spacing` property to the `ToggleGroup` component and updates the related utilities to handle this new property.

Enhancements to `ToggleGroup` component:

* [`packages/ui-togglegroup/src/components/ToggleGroup/ToggleGroup.tsx`](diffhunk://#diff-cc818988cbc6be034006b39a8a4ffbb530489ce2f633c281a97bdba05aeaeac9R20-R24): Added `spacing` property to the `ToggleGroup` component and updated the `toggleGroupClasses` to include `spacing` in its parameters.

Updates to utilities:

* [`packages/ui-togglegroup/src/components/ToggleGroup/utilities.ts`](diffhunk://#diff-20d97d2589ee02220d04b0855fa3443df9aae59c5712a4d8259fbdf63278604dR1-R4): Imported `SpacingProps` and `getSpacing` from `@versini/ui-private/dist/utilities`.
* [`packages/ui-togglegroup/src/components/ToggleGroup/utilities.ts`](diffhunk://#diff-20d97d2589ee02220d04b0855fa3443df9aae59c5712a4d8259fbdf63278604dL56-R76): Modified `getToggleGroupClasses` function to accept and utilize the new `spacing` property.