### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,7 +6,7 @@
 	"packages/ui-components": "5.31.14",
 	"packages/ui-fingerprint": "1.0.1",
 	"packages/ui-footer": "1.0.8",
-	"packages/ui-form": "1.7.0",
+	"packages/ui-form": "1.7.1",
 	"packages/ui-header": "1.0.8",
 	"packages/ui-hooks": "4.2.1",
 	"packages/ui-icons": "1.14.0",
@@ -22,6 +22,6 @@
 	"packages/ui-textarea": "1.0.7",
 	"packages/ui-textinput": "1.2.0",
 	"packages/ui-toggle": "1.0.7",
-	"packages/ui-togglegroup": "1.0.0",
+	"packages/ui-togglegroup": "1.1.0",
 	"packages/ui-truncate": "1.0.7"
 }

--- a/packages/ui-form/CHANGELOG.md
+++ b/packages/ui-form/CHANGELOG.md
@@ -35,6 +35,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [1.7.1](https://github.com/versini-org/ui-components/compare/ui-form-v1.7.0...ui-form-v1.7.1) (2024-10-05)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-togglegroup bumped to 1.1.0
+
 ## [1.7.0](https://github.com/versini-org/ui-components/compare/ui-form-v1.6.12...ui-form-v1.7.0) (2024-10-04)
 
 

--- a/packages/ui-form/package.json
+++ b/packages/ui-form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-form",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-form/stats/stats.json
+++ b/packages/ui-form/stats/stats.json
@@ -544,5 +544,19 @@
       "limit": "67 KB",
       "passed": true
     }
+  },
+  "1.7.1": {
+    "../bundlesize/dist/form/assets/index.js": {
+      "fileSize": 34585,
+      "fileSizeGzip": 9771,
+      "limit": "20 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/form/assets/vendor.js": {
+      "fileSize": 142129,
+      "fileSizeGzip": 45524,
+      "limit": "67 KB",
+      "passed": true
+    }
   }
 }

--- a/packages/ui-togglegroup/CHANGELOG.md
+++ b/packages/ui-togglegroup/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.1.0](https://github.com/versini-org/ui-components/compare/ui-togglegroup-v1.0.0...ui-togglegroup-v1.1.0) (2024-10-05)
+
+
+### Features
+
+* **ToggleGroup:** adding visual separators between toggles ([#720](https://github.com/versini-org/ui-components/issues/720)) ([fc97306](https://github.com/versini-org/ui-components/commit/fc97306c2d3760f6279c9a496ac6aeb8910f17a5))
+
+
+### Bug Fixes
+
+* **ui-togglegroup:** adding missing spacing implementation ([#718](https://github.com/versini-org/ui-components/issues/718)) ([1ae1f2a](https://github.com/versini-org/ui-components/commit/1ae1f2ac8eb54d35a581d895e059ebf60d0aad1a))
+
 ## 1.0.0 (2024-10-04)
 
 

--- a/packages/ui-togglegroup/package.json
+++ b/packages/ui-togglegroup/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-togglegroup",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-form: 1.7.1</summary>

## [1.7.1](https://github.com/versini-org/ui-components/compare/ui-form-v1.7.0...ui-form-v1.7.1) (2024-10-05)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-togglegroup bumped to 1.1.0
</details>

<details><summary>ui-togglegroup: 1.1.0</summary>

## [1.1.0](https://github.com/versini-org/ui-components/compare/ui-togglegroup-v1.0.0...ui-togglegroup-v1.1.0) (2024-10-05)


### Features

* **ToggleGroup:** adding visual separators between toggles ([#720](https://github.com/versini-org/ui-components/issues/720)) ([fc97306](https://github.com/versini-org/ui-components/commit/fc97306c2d3760f6279c9a496ac6aeb8910f17a5))


### Bug Fixes

* **ui-togglegroup:** adding missing spacing implementation ([#718](https://github.com/versini-org/ui-components/issues/718)) ([1ae1f2a](https://github.com/versini-org/ui-components/commit/1ae1f2ac8eb54d35a581d895e059ebf60d0aad1a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).