### PR TITLE
feat(MenuItem): adding "raw" prop

### DIFF
--- a/packages/documentation/src/Components/Menu.stories.tsx
+++ b/packages/documentation/src/Components/Menu.stories.tsx
@@ -10,6 +10,7 @@ import {
 } from "@versini/ui-icons";
 import { Menu, MenuItem, MenuSeparator } from "@versini/ui-menu";
 import { Panel } from "@versini/ui-panel";
+import { ToggleGroup, ToggleGroupItem } from "@versini/ui-togglegroup";
 import { useState } from "react";
 
 export default {
@@ -163,5 +164,51 @@ export const WithMessageBox: Story<any> = (args) => {
 				<Button size="small">Button</Button>
 			</div>
 		</>
+	);
+};
+
+export const RawItem: Story<any> = (args) => {
+	const [value, setValue] = useState("Anthropic");
+	return (
+		<div className="flex h-96 min-h-10 flex-wrap p-11">
+			<Button size="small" noBorder spacing={{ r: 2 }}>
+				Button
+			</Button>
+			<Menu
+				trigger={
+					<ButtonIcon>
+						<IconSettings />
+					</ButtonIcon>
+				}
+				spacing={{ r: 2 }}
+				{...args}
+			>
+				<MenuItem label="Profile" />
+				<MenuItem label="Statistics" />
+				<MenuItem label="History" />
+				<MenuSeparator />
+				<MenuItem raw ignoreClick>
+					<ToggleGroup
+						size="small"
+						mode="dark"
+						focusMode="light"
+						value={value}
+						onValueChange={(value: string) => {
+							if (value) {
+								setValue(value);
+							}
+						}}
+					>
+						<ToggleGroupItem value="OpenAI" />
+						<ToggleGroupItem value="Anthropic" />
+					</ToggleGroup>
+				</MenuItem>
+				<MenuSeparator />
+				<MenuItem label="About" />
+			</Menu>
+			<Button size="small" noBorder>
+				Button
+			</Button>
+		</div>
 	);
 };

--- a/packages/ui-menu/src/components/Menu/MenuItem.tsx
+++ b/packages/ui-menu/src/components/Menu/MenuItem.tsx
@@ -8,35 +8,69 @@ import type { MenuItemProps, MenuSeparatorProps } from "./MenuTypes";
 export const MenuItem = React.forwardRef<
 	HTMLButtonElement,
 	MenuItemProps & React.ButtonHTMLAttributes<HTMLButtonElement>
->(({ label, disabled, icon, ...props }, forwardedRef) => {
-	const menu = React.useContext(MenuContext);
-	const item = useListItem({ label: disabled ? null : label });
-	const tree = useFloatingTree();
+>(
+	(
+		{
+			label,
+			disabled,
+			icon,
+			raw = false,
+			children,
+			ignoreClick = false,
+			...props
+		},
+		forwardedRef,
+	) => {
+		const menu = React.useContext(MenuContext);
+		const item = useListItem({ label: disabled ? null : label });
+		const tree = useFloatingTree();
+		const mergedRef = useMergeRefs([item.ref, forwardedRef]);
 
-	return (
-		<button
-			{...props} // this needs to be first to allow override
-			ref={useMergeRefs([item.ref, forwardedRef])}
-			role="menuitem"
-			className="m-0 flex w-full rounded-md border border-transparent bg-none px-3 py-2 text-left text-base outline-none focus:border focus:border-border-medium focus:bg-surface-lighter focus:underline disabled:cursor-not-allowed disabled:text-copy-medium sm:py-1"
-			tabIndex={0}
-			disabled={disabled}
-			{...menu.getItemProps({
-				onClick(event: React.MouseEvent<HTMLButtonElement>) {
-					props.onClick?.(event);
-					tree?.events.emit("click");
-				},
-				onFocus(event: React.FocusEvent<HTMLButtonElement>) {
-					props.onFocus?.(event);
-					menu.setHasFocusInside(true);
-				},
-			})}
-		>
-			{icon}
-			{label && <span className="pl-2">{label}</span>}
-		</button>
-	);
-});
+		if (raw && children) {
+			return (
+				<div
+					role="menuitem"
+					{...menu.getItemProps({
+						onClick(event: React.MouseEvent<HTMLButtonElement>) {
+							if (!ignoreClick) {
+								props.onClick?.(event);
+								tree?.events.emit("click");
+							}
+						},
+					})}
+				>
+					{children}
+				</div>
+			);
+		}
+
+		return (
+			<button
+				{...props} // this needs to be first to allow override
+				ref={mergedRef}
+				role="menuitem"
+				className="m-0 flex w-full rounded-md border border-transparent bg-none px-3 py-2 text-left text-base outline-none focus:border focus:border-border-medium focus:bg-surface-lighter focus:underline disabled:cursor-not-allowed disabled:text-copy-medium sm:py-1"
+				tabIndex={0}
+				disabled={disabled}
+				{...menu.getItemProps({
+					onClick(event: React.MouseEvent<HTMLButtonElement>) {
+						if (!ignoreClick) {
+							props.onClick?.(event);
+							tree?.events.emit("click");
+						}
+					},
+					onFocus(event: React.FocusEvent<HTMLButtonElement>) {
+						props.onFocus?.(event);
+						menu.setHasFocusInside(true);
+					},
+				})}
+			>
+				{icon}
+				{label && <span className="pl-2">{label}</span>}
+			</button>
+		);
+	},
+);
 
 MenuItem.displayName = "MenuItem";
 

--- a/packages/ui-menu/src/components/Menu/MenuTypes.d.ts
+++ b/packages/ui-menu/src/components/Menu/MenuTypes.d.ts
@@ -40,7 +40,7 @@ export type MenuItemProps = {
 	/**
 	 * The label to use for the menu item.
 	 */
-	label: string;
+	label?: string;
 	/**
 	 * Whether or not the menu item is disabled.
 	 * @default false
@@ -50,6 +50,14 @@ export type MenuItemProps = {
 	 * A React component of type Icon to be placed on the left of the label.
 	 */
 	icon?: React.ReactNode;
+	/**
+	 * Disable internal menu item behavior (click, focus, etc.).
+	 */
+	raw?: boolean;
+	/**
+	 * Whether or not the menu should close when the menu item is selected.
+	 */
+	ignoreClick?: boolean;
 };
 
 export type MenuSeparatorProps = React.HTMLAttributes<HTMLDivElement>;

--- a/packages/ui-menu/src/components/Menu/__tests__/Menu.test.tsx
+++ b/packages/ui-menu/src/components/Menu/__tests__/Menu.test.tsx
@@ -31,6 +31,20 @@ const SimpleMenu = ({ ...props }) => (
 	</Menu>
 );
 
+const SimpleMenuWithRawItem = ({ ...props }) => (
+	<Menu trigger={<button>Click Me</button>} {...props}>
+		<MenuItem label={FIRST_MENU_ITEM} />
+		<MenuItem label={SECOND_MENU_ITEM} />
+		<MenuItem label={THIRD_MENU_ITEM} disabled />
+		<MenuItem label={FOURTH_MENU_ITEM} />
+		<MenuSeparator data-testid="menu-separator" />
+		<MenuItem label={FIFTH_MENU_ITEM} />
+		<MenuItem raw>
+			<button>Raw Item</button>
+		</MenuItem>
+	</Menu>
+);
+
 const SimpleMenuIcon = ({ ...props }) => (
 	<Menu
 		trigger={
@@ -257,5 +271,45 @@ describe("Menu behaviors", () => {
 
 		const separator = screen.getByTestId("menu-separator");
 		expect(separator).toBeInTheDocument();
+	});
+
+	it("should have a raw menu item when menu is opened", async () => {
+		const { user } = renderWithUserEvent(
+			<SimpleMenuWithRawItem label={MENU_TRIGGER_LABEL} />,
+		);
+		const trigger = screen.getByLabelText(MENU_TRIGGER_LABEL);
+		await user.click(trigger);
+		const firstMenuItem = screen.getByRole("menuitem", {
+			name: FIRST_MENU_ITEM,
+		});
+
+		expect(firstMenuItem).toHaveFocus();
+		expect(document.activeElement).toBe(firstMenuItem);
+
+		const rawItem = screen.getByRole("menuitem", { name: "Raw Item" });
+		expect(rawItem).toBeInTheDocument();
+	});
+
+	it("should trigger the MenuItem onClick callback when a raw menuitem is selected", async () => {
+		const onClick = vi.fn();
+		const { user } = renderWithUserEvent(
+			<Menu trigger={<button>Click Me</button>} label={MENU_TRIGGER_LABEL}>
+				<MenuItem label={FIRST_MENU_ITEM} onClick={onClick} raw>
+					<button>Raw Item</button>
+				</MenuItem>
+				<MenuItem label={SECOND_MENU_ITEM} />
+				<MenuItem label={THIRD_MENU_ITEM} disabled />
+				<MenuItem label={FOURTH_MENU_ITEM} />
+			</Menu>,
+		);
+		const trigger = screen.getByLabelText(MENU_TRIGGER_LABEL);
+		await user.click(trigger);
+		const firstMenuItem = screen.getByRole("menuitem", {
+			name: "Raw Item",
+		});
+
+		await user.click(firstMenuItem);
+		expect(trigger).toHaveFocus();
+		expect(onClick).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
This pull request introduces a new feature for handling raw menu items in the `Menu` component and updates the documentation and tests accordingly. The most important changes include adding support for raw menu items in `MenuItem`, creating a new story in the documentation, and updating the test suite to cover the new functionality.

### New Feature: Raw Menu Items

* [`packages/ui-menu/src/components/Menu/MenuItem.tsx`](diffhunk://#diff-b98fa67669fc6c42b3c8bca567d39ccb4b5fae4d2f6cf34345dbe5749b72f3efL11-R60): Added support for raw menu items by introducing the `raw` and `ignoreClick` props. Modified the component to render a `div` with `role="menuitem"` when `raw` is true. [[1]](diffhunk://#diff-b98fa67669fc6c42b3c8bca567d39ccb4b5fae4d2f6cf34345dbe5749b72f3efL11-R60) [[2]](diffhunk://#diff-b98fa67669fc6c42b3c8bca567d39ccb4b5fae4d2f6cf34345dbe5749b72f3efL39-R73)

### Documentation Updates

* [`packages/documentation/src/Components/Menu.stories.tsx`](diffhunk://#diff-38e03e431f106b2c80e5e6c37a827f0c600274e8fc7bb7280b1233c4440a8d23R169-R214): Added a new story `RawItem` to demonstrate the usage of raw menu items with `ToggleGroup` inside a `MenuItem`.
* [`packages/documentation/src/Components/Menu.stories.tsx`](diffhunk://#diff-38e03e431f106b2c80e5e6c37a827f0c600274e8fc7bb7280b1233c4440a8d23R13): Imported `ToggleGroup` and `ToggleGroupItem` from `@versini/ui-togglegroup` to support the new story.

### Test Suite Enhancements

* [`packages/ui-menu/src/components/Menu/__tests__/Menu.test.tsx`](diffhunk://#diff-eb0374cce0d1b1e35be93af5f58eb160b6cf419f1bef5a82a7759fa35034ca7fR34-R47): Added new tests to verify the behavior of raw menu items, including their rendering and click handling. [[1]](diffhunk://#diff-eb0374cce0d1b1e35be93af5f58eb160b6cf419f1bef5a82a7759fa35034ca7fR34-R47) [[2]](diffhunk://#diff-eb0374cce0d1b1e35be93af5f58eb160b6cf419f1bef5a82a7759fa35034ca7fR275-R314)