### PR TITLE
fix(ui-hooks): getHostkeyHandler is not exported

### DIFF
--- a/packages/ui-hooks/src/hooks/index.ts
+++ b/packages/ui-hooks/src/hooks/index.ts
@@ -1,4 +1,4 @@
-import { useHotkeys } from "./useHotkeys";
+import { getHotkeyHandler, useHotkeys } from "./useHotkeys";
 import { useIsMounted } from "./useIsMounted";
 import { useLocalStorage } from "./useLocalStorage";
 import { useMergeRefs } from "./useMergeRefs";
@@ -7,6 +7,7 @@ import { useUncontrolled } from "./useUncontrolled";
 import { useUniqueId } from "./useUniqueId";
 
 export {
+	getHotkeyHandler,
 	useHotkeys,
 	useIsMounted,
 	useLocalStorage,


### PR DESCRIPTION
This pull request includes updates to the `packages/ui-hooks/src/hooks/index.ts` file to enhance hotkey handling functionality.

Enhancements to hotkey handling:

* [`packages/ui-hooks/src/hooks/index.ts`](diffhunk://#diff-3e5215078e5fb7d79f14b0cb95e4c4d37cb0131b6edd284e04b56b72166f1ca8L1-R1): Added the `getHotkeyHandler` function to the list of imports and exports to improve hotkey handling capabilities. [[1]](diffhunk://#diff-3e5215078e5fb7d79f14b0cb95e4c4d37cb0131b6edd284e04b56b72166f1ca8L1-R1) [[2]](diffhunk://#diff-3e5215078e5fb7d79f14b0cb95e4c4d37cb0131b6edd284e04b56b72166f1ca8R10)