### PR TITLE
chore: remove warning about use-client from third-party deps

### DIFF
--- a/configuration/vite.common.ts
+++ b/configuration/vite.common.ts
@@ -141,6 +141,13 @@ try {
 							return "";
 						},
 					},
+					// discard warnings about "use client" in Radix components
+					onwarn(warning, warn) {
+						if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
+							return;
+						}
+						warn(warning);
+					},
 				},
 			},
 			esbuild: {


### PR DESCRIPTION
This pull request includes a change to the `configuration/vite.common.ts` file to handle specific warnings during the build process.

Build process improvements:

* [`configuration/vite.common.ts`](diffhunk://#diff-6f5b496211fd8ec4cb31b34e61f07825512dba4ec3830ebd59fb2c086fc2a59bR144-R150): Added an `onwarn` handler to discard warnings about "use client" in Radix components.