### PR TITLE
chore: using react plugin for Vite

### DIFF
--- a/configuration/vite.common.ts
+++ b/configuration/vite.common.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import react from "@vitejs/plugin-react";
 
 import fs from "fs-extra";
 import { glob } from "glob";
@@ -141,13 +142,6 @@ try {
 							return "";
 						},
 					},
-					// discard warnings about "use client" in Radix components
-					onwarn(warning, warn) {
-						if (warning.code === "MODULE_LEVEL_DIRECTIVE") {
-							return;
-						}
-						warn(warning);
-					},
 				},
 			},
 			esbuild: {
@@ -155,7 +149,7 @@ try {
 					"top-level-await": true,
 				},
 			},
-			plugins: [],
+			plugins: [react()],
 		};
 	});
 };


### PR DESCRIPTION
This pull request includes changes to the `configuration/vite.common.ts` file to integrate the React plugin and remove unnecessary warning suppression for Radix components.

Integration of React plugin:

* [`configuration/vite.common.ts`](diffhunk://#diff-6f5b496211fd8ec4cb31b34e61f07825512dba4ec3830ebd59fb2c086fc2a59bR3): Added import statement for the React plugin from `@vitejs/plugin-react`.
* [`configuration/vite.common.ts`](diffhunk://#diff-6f5b496211fd8ec4cb31b34e61f07825512dba4ec3830ebd59fb2c086fc2a59bL144-R152): Added the React plugin to the `plugins` array in the Vite configuration.

Removal of unnecessary warning suppression:

* [`configuration/vite.common.ts`](diffhunk://#diff-6f5b496211fd8ec4cb31b34e61f07825512dba4ec3830ebd59fb2c086fc2a59bL144-R152): Removed the `onwarn` function that was discarding warnings about "use client" in Radix components.