### PR TITLE
feat(TableCellSort): adding prop buttonClassName

### DIFF
--- a/packages/ui-table/src/components/Table/Table.tsx
+++ b/packages/ui-table/src/components/Table/Table.tsx
@@ -17,6 +17,7 @@ import {
 	CELL_WRAPPER_HEAD,
 	TableCellSortDirections,
 	getTableCellClasses,
+	getTableCellSortButtonClasses,
 	getTableClasses,
 	getTableFooterClasses,
 	getTableHeadClasses,
@@ -153,6 +154,7 @@ export const TableCell = ({
 export const TableCellSort = ({
 	align,
 	children,
+	buttonClassName,
 	className,
 	component,
 	focusMode = "alt-system",
@@ -163,6 +165,7 @@ export const TableCellSort = ({
 	cellId,
 	...otherProps
 }: TableCellSortProps) => {
+	const buttonClass = getTableCellSortButtonClasses({ buttonClassName });
 	return (
 		<TableCell
 			component={component}
@@ -180,7 +183,7 @@ export const TableCellSort = ({
 		>
 			<ButtonSort_private
 				active={sortedCell === cellId}
-				className="rounded-none text-sm"
+				className={buttonClass}
 				onClick={onClick}
 				align={align}
 				noBorder

--- a/packages/ui-table/src/components/Table/TableTypes.d.ts
+++ b/packages/ui-table/src/components/Table/TableTypes.d.ts
@@ -90,6 +90,10 @@ export type TableCellSortProps = {
 	 */
 	align?: "left" | "center" | "right";
 	/**
+	 * CSS class to apply to the button within the sort table cell.
+	 */
+	buttonClassName?: string;
+	/**
 	 * The type of cell.
 	 * @default "td"
 	 */

--- a/packages/ui-table/src/components/Table/__tests__/Table.test.tsx
+++ b/packages/ui-table/src/components/Table/__tests__/Table.test.tsx
@@ -541,6 +541,35 @@ describe("Table components", () => {
 		expect(tableCell.tagName).toBe("TD");
 	});
 
+	it("should render a sortable table cell with custom CSS for the button", async () => {
+		render(
+			<table>
+				<tbody>
+					<tr>
+						<TableCellSort
+							buttonClassName="toto"
+							cellId="cell-id"
+							sortDirection="asc"
+							sortedCell="cell-id"
+							onClick={() => {}}
+							data-testid="table-cell-sort"
+						>
+							hello
+						</TableCellSort>
+					</tr>
+				</tbody>
+			</table>,
+		);
+		const tableCell = await screen.findByTestId("table-cell-sort");
+		expect(tableCell).toBeInTheDocument();
+		expect(tableCell.tagName).toBe("TD");
+		expect(tableCell.querySelector("svg")).toBeInTheDocument();
+		expect(tableCell).toHaveAttribute("aria-sort", "ascending");
+
+		const button = await screen.findByRole("button");
+		expectToHaveClasses(button, ["toto", "rounded-none", "text-sm"]);
+	});
+
 	it("should render a sortable table cell with ASC icon", async () => {
 		render(
 			<table>

--- a/packages/ui-table/src/components/Table/utilities.ts
+++ b/packages/ui-table/src/components/Table/utilities.ts
@@ -163,3 +163,11 @@ export const getTableCellClasses = ({
 		"px-4 py-1": compact,
 	});
 };
+
+export const getTableCellSortButtonClasses = ({
+	buttonClassName,
+}: {
+	buttonClassName?: string;
+}) => {
+	return clsx("rounded-none text-sm", buttonClassName);
+};


### PR DESCRIPTION
This pull request to `packages/ui-table` includes changes to add custom CSS class support for sortable table cell buttons and accompanying tests. The most important changes include adding a new utility function to generate button classes, updating the `TableCellSort` component to use this function, and adding a test case for the new functionality.

Support for custom CSS classes in sortable table cells:

* [`packages/ui-table/src/components/Table/utilities.ts`](diffhunk://#diff-e6fae39efaa589c565a1a7f25c8f35e744fc9bca9dd10ad02f3bf0baf2956ba6R166-R173): Added a new function `getTableCellSortButtonClasses` to generate button classes for sortable table cells.
* [`packages/ui-table/src/components/Table/Table.tsx`](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR20): Updated the `TableCellSort` component to use the new `getTableCellSortButtonClasses` function and added a `buttonClassName` prop. [[1]](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR20) [[2]](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR157) [[3]](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR168) [[4]](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fL183-R186)

Testing for custom CSS classes:

* [`packages/ui-table/src/components/Table/__tests__/Table.test.tsx`](diffhunk://#diff-b6ba3ad2d23c2afe5a54f357adaa1604ff772d463cde1549d44657b466824925R544-R572): Added a new test case to verify that the sortable table cell renders with custom CSS classes for the button.