### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -23,5 +23,5 @@
 	"packages/ui-textinput": "1.3.1",
 	"packages/ui-toggle": "1.1.1",
 	"packages/ui-togglegroup": "1.2.1",
-	"packages/ui-truncate": "1.1.1"
+	"packages/ui-truncate": "1.1.2"
 }

--- a/packages/ui-truncate/CHANGELOG.md
+++ b/packages/ui-truncate/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.2](https://github.com/versini-org/ui-components/compare/ui-truncate-v1.1.1...ui-truncate-v1.1.2) (2024-12-21)
+
+
+### Bug Fixes
+
+* **Truncate:** force word break even if there is no truncation ([#777](https://github.com/versini-org/ui-components/issues/777)) ([3b9b79f](https://github.com/versini-org/ui-components/commit/3b9b79f0bff44a915e5eb1b40626c346c041b728))
+
 ## [1.1.1](https://github.com/versini-org/ui-components/compare/ui-truncate-v1.1.0...ui-truncate-v1.1.1) (2024-12-18)
 
 

--- a/packages/ui-truncate/package.json
+++ b/packages/ui-truncate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-truncate",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-truncate: 1.1.2</summary>

## [1.1.2](https://github.com/versini-org/ui-components/compare/ui-truncate-v1.1.1...ui-truncate-v1.1.2) (2024-12-21)


### Bug Fixes

* **Truncate:** force word break even if there is no truncation ([#777](https://github.com/versini-org/ui-components/issues/777)) ([3b9b79f](https://github.com/versini-org/ui-components/commit/3b9b79f0bff44a915e5eb1b40626c346c041b728))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).