### PR TITLE
fix(Bubble)!: removing spacing prop in favor of Tailwind classes

### DIFF
--- a/packages/api/src/stories/Components/Bubble.stories.tsx
+++ b/packages/api/src/stories/Components/Bubble.stories.tsx
@@ -36,7 +36,7 @@ export const Basic: Story = {
 	...commonControlsSetup,
 	render: (args) => (
 		<div className="h-96 min-h-10 bg-slate-900 p-11 w-96">
-			<Bubble kind="right" spacing={{ b: 4 }} {...args}>
+			<Bubble kind="right" className="mb-4" {...args}>
 				Right bubble...
 			</Bubble>
 
@@ -52,21 +52,21 @@ export const Copy: Story = {
 	...commonControlsSetup,
 	render: (args) => (
 		<div className=" bg-slate-900 h-full min-h-10 p-11">
-			<Bubble kind="right" spacing={{ b: 4 }} copyToClipboard {...args}>
+			<Bubble kind="right" className="mb-4" copyToClipboard {...args}>
 				Right bubble...
 			</Bubble>
 
-			<Bubble kind="left" spacing={{ b: 4 }} copyToClipboard {...args}>
+			<Bubble kind="left" className="mb-4" copyToClipboard {...args}>
 				Pure string with boolean
 			</Bubble>
 
-			<Bubble kind="left" spacing={{ b: 4 }} copyToClipboard {...args}>
+			<Bubble kind="left" className="mb-4" copyToClipboard {...args}>
 				<div>DOM element with boolean</div>
 			</Bubble>
 
 			<Bubble
 				kind="left"
-				spacing={{ b: 4 }}
+				className="mb-4"
 				copyToClipboard={() => {
 					navigator.clipboard.writeText("DOM element with function");
 				}}
@@ -86,7 +86,7 @@ export const LongText: Story = {
 	...commonControlsSetup,
 	render: (args) => (
 		<div className="h-full min-h-10 bg-slate-900 p-11">
-			<Bubble kind="right" spacing={{ b: 4 }} {...args}>
+			<Bubble kind="right" className="mb-4" {...args}>
 				I have Vodka, St Germain and Grapefruit Juice. Can you suggest a few
 				cocktails I can make with these ingredients?
 			</Bubble>
@@ -156,7 +156,7 @@ export const WithFooter: Story = {
 		<div className="h-96 min-h-10 bg-slate-900 p-11">
 			<Bubble
 				kind="right"
-				spacing={{ b: 4 }}
+				className="mb-4"
 				footer={{
 					Model: "gpt-4-1106-preview",
 				}}

--- a/packages/ui-bubble/package.json
+++ b/packages/ui-bubble/package.json
@@ -14,9 +14,7 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -41,12 +39,9 @@
 		"@tailwindcss/typography": "0.5.15",
 		"@versini/ui-button": "workspace:../ui-button",
 		"@versini/ui-icons": "workspace:../ui-icons",
-		"@versini/ui-spacing": "workspace:../ui-spacing",
 		"@versini/ui-types": "workspace:../ui-types",
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.17"
 	},
-	"sideEffects": [
-		"**/*.css"
-	]
+	"sideEffects": ["**/*.css"]
 }

--- a/packages/ui-bubble/src/components/Bubble/Bubble.tsx
+++ b/packages/ui-bubble/src/components/Bubble/Bubble.tsx
@@ -14,10 +14,9 @@ export const Bubble = ({
 	copyToClipboard,
 	copyToClipboardFocusMode = "system",
 	copyToClipboardMode = "system",
-	spacing,
 }: BubbleProps) => {
 	const [copied, setCopied] = useState(false);
-	const bubbleClasses = getBubbleClasses({ kind, className, spacing });
+	const bubbleClasses = getBubbleClasses({ kind, className });
 	const isCopyToClipboardEnabled =
 		Boolean(copyToClipboard) &&
 		(typeof copyToClipboard === "function" ||

--- a/packages/ui-bubble/src/components/Bubble/BubbleTypes.d.ts
+++ b/packages/ui-bubble/src/components/Bubble/BubbleTypes.d.ts
@@ -1,5 +1,3 @@
-import type { SpacingTypes } from "@versini/ui-types";
-
 export type BubbleProps = {
 	/**
 	 * The text to render in the bubble.
@@ -50,4 +48,4 @@ export type BubbleProps = {
 	 * Same as "footer" but accepts raw JSX.
 	 */
 	rawFooter?: React.ReactNode;
-} & SpacingTypes.Props;
+};

--- a/packages/ui-bubble/src/components/Bubble/__tests__/Bubble.test.tsx
+++ b/packages/ui-bubble/src/components/Bubble/__tests__/Bubble.test.tsx
@@ -12,6 +12,17 @@ describe("Bubble (exceptions)", () => {
 	});
 });
 
+describe("Bubble spacing", () => {
+	it("should render a button with a right margin spacing", async () => {
+		render(<Bubble className="mr-2">hello</Bubble>);
+		const bubble = await screen.findByText("hello");
+		// not only it should be there, but it should be the last entry
+		const classes = bubble.parentElement?.parentElement?.className;
+		expect(classes).toContain("mr-2");
+		expect(classes?.slice(-4)).toBe("mr-2");
+	});
+});
+
 describe("Bubble modifiers", () => {
 	it("should render a left bubble", async () => {
 		render(<Bubble kind="left">hello</Bubble>);

--- a/packages/ui-bubble/src/components/Bubble/utilities.ts
+++ b/packages/ui-bubble/src/components/Bubble/utilities.ts
@@ -1,5 +1,3 @@
-import { getSpacing } from "@versini/ui-spacing";
-import type { SpacingTypes } from "@versini/ui-types";
 import clsx from "clsx";
 
 import { BUBBLE_CLASSNAME } from "../../common/constants";
@@ -34,19 +32,17 @@ const getBubbleBorderClasses = ({ kind }: { kind: string }) => {
 export const getBubbleClasses = ({
 	kind,
 	className,
-	spacing,
 }: {
 	kind: string;
 	className?: string;
-} & SpacingTypes.Props) => {
+}) => {
 	const wrapper = clsx(
-		className,
 		BUBBLE_CLASSNAME,
 		"flex items-start",
-		getSpacing(spacing),
 		{
 			"flex-row-reverse": kind === "right",
 		},
+		className,
 	);
 	const main = clsx(
 		"flex flex-col empty:hidden",

--- a/packages/ui-bubble/tailwind.config.js
+++ b/packages/ui-bubble/tailwind.config.js
@@ -1,2 +1,2 @@
 import { commonTailwindConfigForComponent } from "../../configuration/tailwind.common";
-export default commonTailwindConfigForComponent();
+export default commonTailwindConfigForComponent("ui-bubble");

--- a/packages/ui-button/package.json
+++ b/packages/ui-button/package.json
@@ -14,9 +14,7 @@
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"build:check": "tsc",
 		"build:js": "vite build",
@@ -42,12 +40,9 @@
 	},
 	"dependencies": {
 		"@tailwindcss/typography": "0.5.15",
-		"@versini/ui-spacing": "workspace:../ui-spacing",
 		"@versini/ui-types": "workspace:../ui-types",
 		"clsx": "2.1.1",
 		"tailwindcss": "3.4.17"
 	},
-	"sideEffects": [
-		"**/*.css"
-	]
+	"sideEffects": ["**/*.css"]
 }

--- a/packages/ui-styles/src/plugins/tailwindcss/tailwindPlugin.ts
+++ b/packages/ui-styles/src/plugins/tailwindcss/tailwindPlugin.ts
@@ -81,7 +81,7 @@ const customPlugins = [
  * anymore. They are using the new TailwindCSS classes, and therefore
  * don't need to be added to the safelist.
  */
-const componentsWithNoSpacingProp = ["ui-button", "ui-truncate"];
+const componentsWithNoSpacingProp = ["ui-button", "ui-truncate", "ui-bubble"];
 
 /**
  * The plugin "merge" function is used to merge the custom configuration with

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,9 +389,6 @@ importers:
       '@versini/ui-icons':
         specifier: workspace:../ui-icons
         version: link:../ui-icons
-      '@versini/ui-spacing':
-        specifier: workspace:../ui-spacing
-        version: link:../ui-spacing
       '@versini/ui-types':
         specifier: workspace:../ui-types
         version: link:../ui-types
@@ -413,9 +410,6 @@ importers:
       '@tailwindcss/typography':
         specifier: 0.5.15
         version: 0.5.15(tailwindcss@3.4.17)
-      '@versini/ui-spacing':
-        specifier: workspace:../ui-spacing
-        version: link:../ui-spacing
       '@versini/ui-types':
         specifier: workspace:../ui-types
         version: link:../ui-types


### PR DESCRIPTION
This pull request includes changes to the `Bubble` component and its associated files to remove the `spacing` prop and simplify the codebase. Additionally, there are some updates to the `package.json` files and Tailwind configuration.

### Changes to the `Bubble` component:

* Removed the `spacing` prop from the `Bubble` component and related utilities. (`packages/ui-bubble/src/components/Bubble/Bubble.tsx`, `packages/ui-bubble/src/components/Bubble/utilities.ts`) [[1]](diffhunk://#diff-49cd6c7e65508b07ee50a8295161e68d0e572620f41b20feb1dcc40e00f210f4L17-R19) [[2]](diffhunk://#diff-e94d433b125c617ec5f41202a39e38ec41f97eb3eacfb3ab35e3b46427dabfa7L1-L2) [[3]](diffhunk://#diff-e94d433b125c617ec5f41202a39e38ec41f97eb3eacfb3ab35e3b46427dabfa7L37-R45)
* Updated the stories to replace the `spacing` prop with the `className` prop for margin spacing. (`packages/api/src/stories/Components/Bubble.stories.tsx`) [[1]](diffhunk://#diff-7e83e88dfce2c4f43ec94611a36e4fcd02ba365ed561e7d27fb82f21d83b5b74L39-R39) [[2]](diffhunk://#diff-7e83e88dfce2c4f43ec94611a36e4fcd02ba365ed561e7d27fb82f21d83b5b74L55-R69) [[3]](diffhunk://#diff-7e83e88dfce2c4f43ec94611a36e4fcd02ba365ed561e7d27fb82f21d83b5b74L89-R89) [[4]](diffhunk://#diff-7e83e88dfce2c4f43ec94611a36e4fcd02ba365ed561e7d27fb82f21d83b5b74L159-R159)
* Added a test case to ensure the `className` prop correctly applies margin spacing. (`packages/ui-bubble/src/components/Bubble/__tests__/Bubble.test.tsx`)

### Updates to `package.json` files:

* Removed the `@versini/ui-spacing` dependency and updated the `files` and `sideEffects` arrays formatting. (`packages/ui-bubble/package.json`, `packages/ui-button/package.json`) [[1]](diffhunk://#diff-da5a7e3c1695e503ef6e31329603beff06d9159d1ea05c6cd1d46ee833752cfcL17-R17) [[2]](diffhunk://#diff-da5a7e3c1695e503ef6e31329603beff06d9159d1ea05c6cd1d46ee833752cfcL44-R46) [[3]](diffhunk://#diff-a1b6324db0776a5f63b4f6867e57f29eea7daadd87c7b03468b47d51dbeea7f6L17-R17) [[4]](diffhunk://#diff-a1b6324db0776a5f63b4f6867e57f29eea7daadd87c7b03468b47d51dbeea7f6L45-R47)

### Tailwind configuration:

* Updated the Tailwind configuration to specify the component name for `ui-bubble`. (`packages/ui-bubble/tailwind.config.js`)
* Added `ui-bubble` to the list of components with no spacing prop in the Tailwind plugin. (`packages/ui-styles/src/plugins/tailwindcss/tailwindPlugin.ts`)