### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -19,7 +19,7 @@
 	"packages/ui-spinner": "2.0.0",
 	"packages/ui-styles": "2.0.0",
 	"packages/ui-svgicon": "2.0.0",
-	"packages/ui-system": "2.0.0",
+	"packages/ui-system": "2.0.1",
 	"packages/ui-table": "2.0.0",
 	"packages/ui-textarea": "2.0.0",
 	"packages/ui-textinput": "2.0.0",

--- a/packages/ui-system/CHANGELOG.md
+++ b/packages/ui-system/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.1](https://github.com/versini-org/ui-components/compare/ui-system-v2.0.0...ui-system-v2.0.1) (2024-12-29)
+
+
+### Bug Fixes
+
+* **Flexgrid:** margins are not taken into account in className prop ([#838](https://github.com/versini-org/ui-components/issues/838)) ([9a5ab9a](https://github.com/versini-org/ui-components/commit/9a5ab9aace78a8efddcaea14ac048c57b06f3e48))
+
 ## [2.0.0](https://github.com/versini-org/ui-components/compare/ui-system-v1.8.1...ui-system-v2.0.0) (2024-12-29)
 
 

--- a/packages/ui-system/package.json
+++ b/packages/ui-system/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-system",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-system: 2.0.1</summary>

## [2.0.1](https://github.com/versini-org/ui-components/compare/ui-system-v2.0.0...ui-system-v2.0.1) (2024-12-29)


### Bug Fixes

* **Flexgrid:** margins are not taken into account in className prop ([#838](https://github.com/versini-org/ui-components/issues/838)) ([9a5ab9a](https://github.com/versini-org/ui-components/commit/9a5ab9aace78a8efddcaea14ac048c57b06f3e48))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).