### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,9 @@
 {
 	"packages/ui-anchor": "1.2.12",
-	"packages/ui-bubble": "2.0.4",
+	"packages/ui-bubble": "2.0.5",
 	"packages/ui-button": "3.0.0",
 	"packages/ui-card": "2.0.3",
-	"packages/ui-components": "5.33.11",
+	"packages/ui-components": "5.33.12",
 	"packages/ui-fingerprint": "1.1.0",
 	"packages/ui-footer": "2.0.3",
 	"packages/ui-form": "1.9.6",

--- a/packages/ui-bubble/CHANGELOG.md
+++ b/packages/ui-bubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.5](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.4...ui-bubble-v2.0.5) (2024-12-30)
+
+
+### Bug Fixes
+
+* **Bubble:** too wide bubble at lower breakpoints ([#848](https://github.com/versini-org/ui-components/issues/848)) ([d7d99fc](https://github.com/versini-org/ui-components/commit/d7d99fc4cca02589ff131823964d4cd257de1060))
+
 ## [2.0.4](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.3...ui-bubble-v2.0.4) (2024-12-30)
 
 

--- a/packages/ui-bubble/package.json
+++ b/packages/ui-bubble/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-bubble",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.33.12](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.11...ui-components-v5.33.12) (2024-12-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-bubble bumped to 2.0.5
+
 ## [5.33.11](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.10...ui-components-v5.33.11) (2024-12-30)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.33.11",
+	"version": "5.33.12",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -1978,5 +1978,25 @@
       "limit": "80 KB",
       "passed": true
     }
+  },
+  "5.33.12": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 49232,
+      "fileSizeGzip": 6999,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 81098,
+      "fileSizeGzip": 11659,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 246674,
+      "fileSizeGzip": 80613,
+      "limit": "80 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-bubble: 2.0.5</summary>

## [2.0.5](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.4...ui-bubble-v2.0.5) (2024-12-30)


### Bug Fixes

* **Bubble:** too wide bubble at lower breakpoints ([#848](https://github.com/versini-org/ui-components/issues/848)) ([d7d99fc](https://github.com/versini-org/ui-components/commit/d7d99fc4cca02589ff131823964d4cd257de1060))
</details>

<details><summary>ui-components: 5.33.12</summary>

## [5.33.12](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.11...ui-components-v5.33.12) (2024-12-30)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-bubble bumped to 2.0.5
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).