### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,9 @@
 {
 	"packages/ui-anchor": "1.2.13",
-	"packages/ui-bubble": "2.0.6",
+	"packages/ui-bubble": "2.0.7",
 	"packages/ui-button": "3.0.1",
 	"packages/ui-card": "2.0.4",
-	"packages/ui-components": "5.33.13",
+	"packages/ui-components": "5.33.14",
 	"packages/ui-fingerprint": "1.1.0",
 	"packages/ui-footer": "2.0.4",
 	"packages/ui-form": "1.9.7",

--- a/packages/ui-bubble/CHANGELOG.md
+++ b/packages/ui-bubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.7](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.6...ui-bubble-v2.0.7) (2024-12-30)
+
+
+### Bug Fixes
+
+* **Bubble:** copy paste icon is too big ([#852](https://github.com/versini-org/ui-components/issues/852)) ([99e4cc3](https://github.com/versini-org/ui-components/commit/99e4cc3dcb0c903128c30429667ff2209aa5c861))
+
 ## [2.0.6](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.5...ui-bubble-v2.0.6) (2024-12-30)
 
 

--- a/packages/ui-bubble/package.json
+++ b/packages/ui-bubble/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-bubble",
-	"version": "2.0.6",
+	"version": "2.0.7",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.33.14](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.13...ui-components-v5.33.14) (2024-12-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-bubble bumped to 2.0.7
+
 ## [5.33.13](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.12...ui-components-v5.33.13) (2024-12-30)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.33.13",
+	"version": "5.33.14",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -2018,5 +2018,25 @@
       "limit": "80 KB",
       "passed": true
     }
+  },
+  "5.33.14": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 49232,
+      "fileSizeGzip": 6999,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 81090,
+      "fileSizeGzip": 11662,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 246674,
+      "fileSizeGzip": 80613,
+      "limit": "80 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-bubble: 2.0.7</summary>

## [2.0.7](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.6...ui-bubble-v2.0.7) (2024-12-30)


### Bug Fixes

* **Bubble:** copy paste icon is too big ([#852](https://github.com/versini-org/ui-components/issues/852)) ([99e4cc3](https://github.com/versini-org/ui-components/commit/99e4cc3dcb0c903128c30429667ff2209aa5c861))
</details>

<details><summary>ui-components: 5.33.14</summary>

## [5.33.14](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.13...ui-components-v5.33.14) (2024-12-30)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-bubble bumped to 2.0.7
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).