### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,9 +1,9 @@
 {
 	"packages/ui-anchor": "1.2.13",
-	"packages/ui-bubble": "2.0.7",
+	"packages/ui-bubble": "2.0.8",
 	"packages/ui-button": "3.0.1",
 	"packages/ui-card": "2.0.4",
-	"packages/ui-components": "5.33.14",
+	"packages/ui-components": "5.33.15",
 	"packages/ui-fingerprint": "1.1.0",
 	"packages/ui-footer": "2.0.4",
 	"packages/ui-form": "1.9.7",

--- a/packages/ui-bubble/CHANGELOG.md
+++ b/packages/ui-bubble/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.8](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.7...ui-bubble-v2.0.8) (2024-12-30)
+
+
+### Bug Fixes
+
+* **Bubble:** bubble max width too big at lower breakpoints ([#854](https://github.com/versini-org/ui-components/issues/854)) ([8dd8332](https://github.com/versini-org/ui-components/commit/8dd83326ffb7047a46eb5ade8f6153c2c52152b3))
+
 ## [2.0.7](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.6...ui-bubble-v2.0.7) (2024-12-30)
 
 

--- a/packages/ui-bubble/package.json
+++ b/packages/ui-bubble/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-bubble",
-	"version": "2.0.7",
+	"version": "2.0.8",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -192,6 +192,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 # Changelog
 
+## [5.33.15](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.14...ui-components-v5.33.15) (2024-12-30)
+
+
+### Dependencies
+
+* The following workspace dependencies were updated
+  * dependencies
+    * @versini/ui-bubble bumped to 2.0.8
+
 ## [5.33.14](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.13...ui-components-v5.33.14) (2024-12-30)
 
 

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@versini/ui-components",
-	"version": "5.33.14",
+	"version": "5.33.15",
 	"license": "MIT",
 	"author": "Arno Versini",
 	"publishConfig": {

--- a/packages/ui-components/stats/stats.json
+++ b/packages/ui-components/stats/stats.json
@@ -2038,5 +2038,25 @@
       "limit": "80 KB",
       "passed": true
     }
+  },
+  "5.33.15": {
+    "../bundlesize/dist/components/assets/style.css": {
+      "fileSize": 49262,
+      "fileSizeGzip": 7006,
+      "limit": "8 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/index.js": {
+      "fileSize": 81102,
+      "fileSizeGzip": 11676,
+      "limit": "12 KB",
+      "passed": true
+    },
+    "../bundlesize/dist/components/assets/vendor.js": {
+      "fileSize": 246674,
+      "fileSizeGzip": 80613,
+      "limit": "80 KB",
+      "passed": true
+    }
   }
 }


### PR DESCRIPTION
:rocket: Automated Release
---


<details><summary>ui-bubble: 2.0.8</summary>

## [2.0.8](https://github.com/versini-org/ui-components/compare/ui-bubble-v2.0.7...ui-bubble-v2.0.8) (2024-12-30)


### Bug Fixes

* **Bubble:** bubble max width too big at lower breakpoints ([#854](https://github.com/versini-org/ui-components/issues/854)) ([8dd8332](https://github.com/versini-org/ui-components/commit/8dd83326ffb7047a46eb5ade8f6153c2c52152b3))
</details>

<details><summary>ui-components: 5.33.15</summary>

## [5.33.15](https://github.com/versini-org/ui-components/compare/ui-components-v5.33.14...ui-components-v5.33.15) (2024-12-30)


### Dependencies

* The following workspace dependencies were updated
  * dependencies
    * @versini/ui-bubble bumped to 2.0.8
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).