### PR TITLE
feat(Header): adding noMargin, noPadding and noBorder props

### DIFF
--- a/packages/ui-header/src/components/Header/Header.tsx
+++ b/packages/ui-header/src/components/Header/Header.tsx
@@ -11,26 +11,39 @@ export const Header = ({
 	mode = "system",
 	noColors = false,
 	sticky = false,
+
+	noBorder = false,
+	noMargin = false,
+	noPadding = false,
 }: HeaderProps) => {
 	const headerClass = clsx(
 		HEADER_CLASSNAME,
 		{
-			"border-border-accent bg-surface-dark":
-				mode === "dark" && !raw && !noColors,
-			"border-border-medium bg-surface-light":
-				mode === "light" && !raw && !noColors,
-			"border-border-accent bg-surface-dark dark:border-border-medium dark:bg-surface-light":
-				mode === "alt-system" && !raw && !noColors,
-			"border-border-medium bg-surface-light dark:border-border-accent dark:bg-surface-dark":
-				mode === "system" && !raw && !noColors,
-			"border-b-4": !raw,
+			"border-border-accent": mode === "dark" && !raw && !noColors && !noBorder,
+			"border-border-medium":
+				mode === "light" && !raw && !noColors && !noBorder,
+			"border-border-accent dark:border-border-medium":
+				mode === "alt-system" && !raw && !noColors && !noBorder,
+			"border-border-medium dark:border-border-accent":
+				mode === "system" && !raw && !noColors && !noBorder,
+			"border-b-4": !raw && !noBorder,
 			"border-transparent": !raw && noColors,
+
+			"bg-surface-dark": mode === "dark" && !raw && !noColors,
+			"bg-surface-light": mode === "light" && !raw && !noColors,
+			"bg-surface-dark dark:bg-surface-light":
+				mode === "alt-system" && !raw && !noColors,
+			"bg-surface-light dark:bg-surface-dark":
+				mode === "system" && !raw && !noColors,
+
 			"sticky top-0 z-50": sticky,
 		},
 		className,
 	);
 	const headerInnerClass = clsx({
-		"mt-0 flex w-full flex-col p-2 md:mx-auto md:max-w-4xl": !raw,
+		"mt-0": !noMargin,
+		"p-2": !noPadding,
+		"flex flex-col w-full md:mx-auto md:max-w-4xl": !raw,
 	});
 
 	return (

--- a/packages/ui-header/src/components/Header/HeaderTypes.d.ts
+++ b/packages/ui-header/src/components/Header/HeaderTypes.d.ts
@@ -13,6 +13,7 @@ export type HeaderProps = {
 	mode?: "dark" | "light" | "system" | "alt-system";
 	/**
 	 * Whether or not to render the Header component with colors.
+	 * @default false
 	 */
 	noColors?: boolean;
 	/**
@@ -22,6 +23,22 @@ export type HeaderProps = {
 	raw?: boolean;
 	/**
 	 * Whether or not to render the Header component with sticky behavior.
+	 * @default false
 	 */
 	sticky?: boolean;
+	/**
+	 * Whether or not to render the Header component with no border.
+	 * @default false
+	 */
+	noBorder?: boolean;
+	/**
+	 * Whether or not to render the Header component with no margin.
+	 * @default false
+	 */
+	noMargin?: boolean;
+	/**
+	 * Whether or not to render the Header component with no padding.
+	 * @default false
+	 */
+	noPadding?: boolean;
 };

--- a/packages/ui-header/src/components/Header/__tests__/Header.test.tsx
+++ b/packages/ui-header/src/components/Header/__tests__/Header.test.tsx
@@ -30,6 +30,7 @@ describe("Header modifiers", () => {
 			"bg-surface-light",
 			"dark:border-border-accent",
 			"dark:bg-surface-dark",
+			"border-b-4",
 		]);
 		expectToHaveClasses(header.children[0], [
 			"mt-0",
@@ -51,6 +52,7 @@ describe("Header modifiers", () => {
 			"bg-surface-dark",
 			"dark:border-border-medium",
 			"dark:bg-surface-light",
+			"border-b-4",
 		]);
 		expectToHaveClasses(header.children[0], [
 			"mt-0",
@@ -70,6 +72,7 @@ describe("Header modifiers", () => {
 			HEADER_CLASSNAME,
 			"border-border-medium",
 			"bg-surface-light",
+			"border-b-4",
 		]);
 		expectToHaveClasses(header.children[0], [
 			"mt-0",
@@ -89,6 +92,7 @@ describe("Header modifiers", () => {
 			HEADER_CLASSNAME,
 			"border-border-accent",
 			"bg-surface-dark",
+			"border-b-4",
 		]);
 		expectToHaveClasses(header.children[0], [
 			"mt-0",
@@ -123,7 +127,7 @@ describe("Header modifiers", () => {
 		expect(header.className).not.toContain("mt-0");
 	});
 
-	it("should render a responsive header tag (system)", async () => {
+	it("should render a sticky responsive header tag (system)", async () => {
 		render(<Header sticky>hello</Header>);
 		const header = await screen.findByRole("banner");
 		expectToHaveClasses(header, [
@@ -135,6 +139,7 @@ describe("Header modifiers", () => {
 			"sticky",
 			"top-0",
 			"z-50",
+			"border-b-4",
 		]);
 		expectToHaveClasses(header.children[0], [
 			"mt-0",
@@ -142,6 +147,88 @@ describe("Header modifiers", () => {
 			"w-full",
 			"flex-col",
 			"p-2",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
+	});
+
+	it("should render a responsive header tag (system) with no borders", async () => {
+		render(<Header noBorder>hello</Header>);
+		const header = await screen.findByRole("banner");
+		expectToHaveClasses(header, [
+			HEADER_CLASSNAME,
+			"bg-surface-light",
+			"dark:bg-surface-dark",
+		]);
+		expectToHaveClasses(header.children[0], [
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
+	});
+
+	it("should render a responsive header tag (system) with no margins", async () => {
+		render(<Header noMargin>hello</Header>);
+		const header = await screen.findByRole("banner");
+		expectToHaveClasses(header, [
+			HEADER_CLASSNAME,
+			"border-border-medium",
+			"bg-surface-light",
+			"dark:border-border-accent",
+			"dark:bg-surface-dark",
+			"border-b-4",
+		]);
+		expectToHaveClasses(header.children[0], [
+			"flex",
+			"w-full",
+			"flex-col",
+			"p-2",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
+	});
+
+	it("should render a responsive header tag (system) with no paddings", async () => {
+		render(<Header noPadding>hello</Header>);
+		const header = await screen.findByRole("banner");
+		expectToHaveClasses(header, [
+			HEADER_CLASSNAME,
+			"border-border-medium",
+			"bg-surface-light",
+			"dark:border-border-accent",
+			"dark:bg-surface-dark",
+			"border-b-4",
+		]);
+		expectToHaveClasses(header.children[0], [
+			"mt-0",
+			"flex",
+			"w-full",
+			"flex-col",
+			"md:mx-auto",
+			"md:max-w-4xl",
+		]);
+	});
+
+	it("should render a responsive header tag (system) with no paddings, margins or border", async () => {
+		render(
+			<Header noPadding noMargin noBorder>
+				hello
+			</Header>,
+		);
+		const header = await screen.findByRole("banner");
+		expectToHaveClasses(header, [
+			HEADER_CLASSNAME,
+			"bg-surface-light",
+			"dark:bg-surface-dark",
+		]);
+		expectToHaveClasses(header.children[0], [
+			"flex",
+			"w-full",
+			"flex-col",
 			"md:mx-auto",
 			"md:max-w-4xl",
 		]);


### PR DESCRIPTION
This pull request adds new customization options for the `Header` component in the `packages/ui-header` package. These changes include the ability to remove borders, margins, and padding, and the corresponding updates to the test cases to ensure these new options work correctly.

### New customization options for `Header` component:

* [`packages/ui-header/src/components/Header/Header.tsx`](diffhunk://#diff-0577ff167517db4abebe26dc9be31c541bb6e4df57ff143a7eac6bf46c836df3R14-R46): Added `noBorder`, `noMargin`, and `noPadding` props to allow more flexible customization of the `Header` component.

### Updates to test cases:

* [`packages/ui-header/src/components/Header/__tests__/Header.test.tsx`](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR33): Updated test cases to include checks for the new `noBorder`, `noMargin`, and `noPadding` props. Added new tests to verify the behavior when these props are used. [[1]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR33) [[2]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR55) [[3]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR75) [[4]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR95) [[5]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faL126-R130) [[6]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR142-R161) [[7]](diffhunk://#diff-e1d425a794111d2a786df6d8eb6fe5e3a1e8db4e8518f9bc328ec653495e47faR173-R235)