### PR TITLE
feat(Table): adding "align" prop to TableCell

### DIFF
--- a/packages/ui-table/src/components/Table/Table.tsx
+++ b/packages/ui-table/src/components/Table/Table.tsx
@@ -131,6 +131,7 @@ export const TableCell = ({
 	children,
 	component,
 	className,
+	align,
 	...otherProps
 }: TableCellProps) => {
 	const context = useContext(TableContext);
@@ -141,6 +142,7 @@ export const TableCell = ({
 		className,
 		mode: context.mode,
 		compact: context.compact,
+		align,
 	});
 	return (
 		<Component className={cellClass} {...otherProps}>

--- a/packages/ui-table/src/components/Table/TableTypes.d.ts
+++ b/packages/ui-table/src/components/Table/TableTypes.d.ts
@@ -55,6 +55,10 @@ export type TableCellProps = {
 	 * @default "td"
 	 */
 	component?: "td" | "th";
+	/**
+	 * Whether to align the cell content to the left, center, or right.
+	 */
+	align?: "left" | "center" | "right";
 } & React.ThHTMLAttributes<HTMLTableCellElement> &
 	React.TdHTMLAttributes<HTMLTableCellElement>;
 

--- a/packages/ui-table/src/components/Table/__tests__/Table.test.tsx
+++ b/packages/ui-table/src/components/Table/__tests__/Table.test.tsx
@@ -541,6 +541,60 @@ describe("Table components", () => {
 		expect(tableCell.tagName).toBe("TD");
 	});
 
+	it("should render a default table cell (td) aligned to the left", async () => {
+		render(
+			<table>
+				<tbody>
+					<tr>
+						<TableCell data-testid="table-cell" align="left">
+							hello
+						</TableCell>
+					</tr>
+				</tbody>
+			</table>,
+		);
+		const tableCell = await screen.findByTestId("table-cell");
+		expect(tableCell).toBeInTheDocument();
+		expect(tableCell.tagName).toBe("TD");
+		expect(tableCell.className).toContain("flex justify-start");
+	});
+
+	it("should render a default table cell (td) aligned to the right", async () => {
+		render(
+			<table>
+				<tbody>
+					<tr>
+						<TableCell data-testid="table-cell" align="right">
+							hello
+						</TableCell>
+					</tr>
+				</tbody>
+			</table>,
+		);
+		const tableCell = await screen.findByTestId("table-cell");
+		expect(tableCell).toBeInTheDocument();
+		expect(tableCell.tagName).toBe("TD");
+		expect(tableCell.className).toContain("flex justify-end");
+	});
+
+	it("should render a default table cell (td) center-aligned", async () => {
+		render(
+			<table>
+				<tbody>
+					<tr>
+						<TableCell data-testid="table-cell" align="center">
+							hello
+						</TableCell>
+					</tr>
+				</tbody>
+			</table>,
+		);
+		const tableCell = await screen.findByTestId("table-cell");
+		expect(tableCell).toBeInTheDocument();
+		expect(tableCell.tagName).toBe("TD");
+		expect(tableCell.className).toContain("flex justify-center");
+	});
+
 	it("should render a sortable table cell with custom CSS for the button", async () => {
 		render(
 			<table>

--- a/packages/ui-table/src/components/Table/utilities.ts
+++ b/packages/ui-table/src/components/Table/utilities.ts
@@ -153,14 +153,19 @@ export const getTableCellClasses = ({
 	className,
 	compact,
 	mode,
+	align,
 }: {
 	mode: string;
 	cellWrapper?: string;
 	className?: string;
 	compact?: boolean;
+	align?: "left" | "center" | "right";
 }) => {
 	return clsx(
 		{
+			"flex justify-start": align === "left",
+			"flex justify-center": align === "center",
+			"flex justify-end": align === "right",
 			"text-copy-light": mode === "dark",
 			"text-copy-dark": mode === "light",
 			"text-copy-light dark:text-copy-dark": mode === "system",


### PR DESCRIPTION
This pull request introduces the ability to align table cells within the `Table` component. The main changes include updating the `TableCell` component to accept an `align` prop, adding corresponding CSS classes for alignment, and implementing tests to ensure the new functionality works correctly.

Enhancements to `Table` component:

* [`packages/ui-table/src/components/Table/Table.tsx`](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR134): Added `align` prop to `TableCell` component and included it in the class generation logic. [[1]](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR134) [[2]](diffhunk://#diff-85d6ad6a92b8ac10c8e2f47311f815a305f61f6d4e1c8ba3e487656b2c8a436fR145)

Testing updates:

* [`packages/ui-table/src/components/Table/__tests__/Table.test.tsx`](diffhunk://#diff-b6ba3ad2d23c2afe5a54f357adaa1604ff772d463cde1549d44657b466824925R544-R597): Added new tests to verify that the `TableCell` component correctly applies alignment classes for left, center, and right alignment.

Utility function updates:

* [`packages/ui-table/src/components/Table/utilities.ts`](diffhunk://#diff-e6fae39efaa589c565a1a7f25c8f35e744fc9bca9dd10ad02f3bf0baf2956ba6R156-R168): Updated `getTableCellClasses` function to handle the new `align` prop and apply the appropriate CSS classes.